### PR TITLE
Fixed invalid xml

### DIFF
--- a/iis/configuration/system.webServer/applicationInitialization/index/samples/sample1.xml
+++ b/iis/configuration/system.webServer/applicationInitialization/index/samples/sample1.xml
@@ -2,7 +2,7 @@
    <applicationInitialization
       doAppInitAfterRestart="true"
       skipManagedModules="true"
-      remapManagedRequestsTo="filename.htm"/>
+      remapManagedRequestsTo="filename.htm">
       <add initializationPage="/default.aspx" hostName="myhost"/>
    </applicationInitialization>
 </system.webServer>


### PR DESCRIPTION
The `applicationInitialization` element should not be closed, since `add` is a child of that element.