### PR TITLE
Fix quotation mark position

### DIFF
--- a/iis/manage/configuring-security/application-pool-identities/samples/sample2.cmd
+++ b/iis/manage/configuring-security/application-pool-identities/samples/sample2.cmd
@@ -1,1 +1,1 @@
-ICACLS test.txt /grant "IIS AppPool\DefaultAppPool":F
+ICACLS test.txt /grant "IIS AppPool\DefaultAppPool:F"


### PR DESCRIPTION
The cmd in file results on a windows server 2016 to an `Invalid parameter "IIS AppPool\DefaultAppPool"`. See also https://serverfault.com/questions/385604