### PR TITLE
Correct errors on anymous vs authenticated

### DIFF
--- a/iis/manage/configuring-security/understanding-iis-url-authorization.md
+++ b/iis/manage/configuring-security/understanding-iis-url-authorization.md
@@ -136,11 +136,11 @@ Suppose the administrator wants to ensure that all users of a particular site mu
 
 [!code-xml[Main](understanding-iis-url-authorization/samples/sample7.xml)]
 
-This configuration denies access to anonymous users (\* = anonymous users, ? = authenticated users). With the lockElements="clear", you ensure that no one on a lower level can clear the inheritance of this setting. Your setting would be inherited to all applications and virtual directories of this site. It comes to a lock violation when you try to use the &lt;clear/&gt; statement at a lower level.
+This configuration denies access to anonymous users (\? = anonymous users, * = all users). With the lockElements="clear", you ensure that no one on a lower level can clear the inheritance of this setting. Your setting would be inherited to all applications and virtual directories of this site. It comes to a lock violation when you try to use the &lt;clear/&gt; statement at a lower level.
 
 For more information on configuration locking, see [https://msdn.microsoft.com/en-us/library/ms178693.aspx](https://msdn.microsoft.com/en-us/library/ms178693.aspx).
 
-You can also lock the clear element in ASP.NET Url Authorization. The problem is that ASP.NET URL Authorization evaluates authorization rules from the bottom up, i.e. it first evaluates rules in the current web.config file before it evaluates parent rules. As soon as a match is found, access is granted or denied. In the above example, you can still grant access to anonymous users by specifying &lt;add users="\*"/&gt; as an authorization rule in the secure web.config file. Because it gets evaluated first, anonymous users would be granted access.
+You can also lock the clear element in ASP.NET Url Authorization. The problem is that ASP.NET URL Authorization evaluates authorization rules from the bottom up, i.e. it first evaluates rules in the current web.config file before it evaluates parent rules. As soon as a match is found, access is granted or denied. In the above example, you can still grant access to anonymous users by specifying &lt;add users="\?"/&gt; as an authorization rule in the secure web.config file. Because it gets evaluated first, anonymous users would be granted access.
 
 The IIS URL Authorization module evaluates deny rules first. Because you deny access to anonymous users, you cannot simply override that rule. The other big difference is that parent rules are evaluated first. This means that if you deny access for Fred at a higher level, you can't allow access to Fred on a lower level.
 

--- a/iis/manage/configuring-security/understanding-iis-url-authorization/samples/sample7.xml
+++ b/iis/manage/configuring-security/understanding-iis-url-authorization/samples/sample7.xml
@@ -1,3 +1,3 @@
 <authorization lockElements="clear"> 
-	<add accessType="Deny" users="*" /> 
+	<add accessType="Deny" users="?" /> 
 </authorization>


### PR DESCRIPTION
This is an update to my former pull request #107.

Here is the original text:

> As can be seen here: https://msdn.microsoft.com/en-us/library/wce3kxhd.aspx
> 
> "Anonymous users are identified using a question mark (?). You can specify all authenticated users using an asterisk (*)."

I created a new pull request which is now based on the current state of the repository (includes newer recent commits) and updates the document following a comment by @bariscaglar .

Sorry for creating a new PR, I would have updated the old one, but I had created it without downloading the repo and just using Github's online editing tools. While this worked, I wasn't able to update it like I normally would (then again, it's been ages since I submitted a pull request).
