### PR TITLE
howto implement appOffline rule included

### DIFF
--- a/iis/publish/troubleshooting-web-deploy/web-deploy-error-codes.md
+++ b/iis/publish/troubleshooting-web-deploy/web-deploy-error-codes.md
@@ -377,6 +377,13 @@ Workaround: From the Programs Control Panel, run Repair on Web Deploy 2.0. Alter
 
 **Resolution**: Make sure that the destination file is not in use before performing a sync. If you are syncing content to a web site hosted on IIS 7 or later (using the appHostConfig, iisApp, or contentPath providers), consider taking the application offline during the sync by enabling the appOffline rule.
 
+You can configure the appOffline rule in the publishing profile (.pubxml). Add the `EnableMSDeployAppOffline` element to the PropertyGroup like this:
+```
+<PropertyGroup>
+  <EnableMSDeployAppOffline>true</EnableMSDeployAppOffline>
+</PropertyGroup>
+```
+
 <a id="ERROR_FAILED_TO_BRING_APP_ONLINE"></a>
 
 ## ERROR\_FAILED\_TO\_BRING\_APP\_ONLINE
@@ -384,6 +391,13 @@ Workaround: From the Programs Control Panel, run Repair on Web Deploy 2.0. Alter
 **Diagnosis**: Web Deploy was not able to remove the app\_offline.htm file from the site after the sync completed.
 
 **Resolution**: You may either rerun the sync with the appOffline rule enabled, or manually delete the app\_offline.htm file from the root of your site on the destination server. For details on the reason for the failure, check the server event logs.
+
+You can configure the appOffline rule in the publishing profile (.pubxml). Add the `EnableMSDeployAppOffline` element to the PropertyGroup like this:
+```
+<PropertyGroup>
+  <EnableMSDeployAppOffline>true</EnableMSDeployAppOffline>
+</PropertyGroup>
+```
 
 <a id="ERROR_HIGHER_FXVERSION_REQUIRED"></a>
 


### PR DESCRIPTION
The documentation mentions for a couple of issues that the appOffline rule can be implemented, but then fails to provide a link to how to implement this rule, and the provided GUI for publish profiles do not include this setting. I found the much referred to, first google search result for `azure app service appoffline rule` on StackOverflow and put it into this document