### PR TITLE
Update installing-and-configuring-web-deploy.md

### DIFF
--- a/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy.md
+++ b/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy.md
@@ -30,7 +30,7 @@ The server must have an operating system that comes with IIS7— this means eith
 
 #### Use WebPI to install Web Deploy along with its dependencies like the Web Management Service (WMSvc)
 
-1. Install Web Deploy by using either method **i** or **ii** below: 
+1. Install Web Deploy by using either method **a** or **b** below: 
 
     1. Install Web Deploy and dependent products using the [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx)
 


### PR DESCRIPTION
Installing Web deploy can be done using "a" and "b" instead of i or ii.

The screen shots of Web Platform Installer is outdated and the search results are not relevant.

Attaching relevant images.

![search](https://user-images.githubusercontent.com/1645488/39783060-348cd306-5314-11e8-8858-1f1eb3258503.png)
![searchresults](https://user-images.githubusercontent.com/1645488/39783065-37424e78-5314-11e8-9173-dcf14fbcf018.png)
