### PR TITLE
Fixed #199

### DIFF
--- a/iis/configuration/system.ftpServer/security/authentication/denyByFailure.md
+++ b/iis/configuration/system.ftpServer/security/authentication/denyByFailure.md
@@ -19,6 +19,9 @@ Deny by Failure &lt;denyByFailure&gt;
 
 The `<denyByFailure>` element configures the FTP service to deny access to the FTP service based upon how many times an FTP client fails to authenticate within a time period. When the number of failed login attempts has been reached, the FTP connection will be closed forcibly, and the client IP address will be blocked from accessing the FTP service for the duration of the time period (as set by the entryExpiration attribute). Denying access by the failure rate can only be enabled for the server, not for individual sites.
 
+> [!NOTE]
+> If the client's IP address matches an Allow Entry of **Specific** IP Address in FTP IP Address and Domain Restrictions feature specified at the **server** level, the client is treated with additional trust and is allowed to bypass FTP Logon Attempts restriction check.
+
 <a id="002"></a>
 ## Compatibility
 


### PR DESCRIPTION
@shirhatti @bangbingsyb Would you review this IIS doc update? This is for adding missing information for FTP Logon Attempt Restriction feature. 

If client's ip matches to an existing static IP "allow" rule only for server level and only for a single IP address rule, FTP Logon Attempt Restriction check is being skipped.