### PR TITLE
Update configure-iis-7-output-caching.md

### DIFF
--- a/iis/manage/managing-performance-settings/configure-iis-7-output-caching.md
+++ b/iis/manage/managing-performance-settings/configure-iis-7-output-caching.md
@@ -62,7 +62,7 @@ Two properties determine cache worthiness:
 - frequentHitTimePeriod
 - frequentHitThreshold
 
-A request is only cached if more than `<frequentHitThreshold>` requests for a cacheable URL arrive within the &lt;frequentHitTimePeriod&gt;. The default setting for frequentHitTimePeriod is 10 seconds. The default setting for frequentHitThreshold is 2 seconds.
+A request is only cached if more than `<frequentHitThreshold>` requests for a cacheable URL arrive within the `<frequentHitTimePeriod>`. The default setting for `frequentHitTimePeriod` is 10 seconds. The default setting for `frequentHitThreshold` is 2 hits.
 
 ## Configure Output Caching Through the IIS Manager
 


### PR DESCRIPTION
I fixed a typo. The default threshold is 2 hits in 10 seconds, not 2 *seconds* in 10 seconds.