### PR TITLE
Web Deploy automatic backup script command fix

### DIFF
--- a/iis/publish/using-web-deploy/web-deploy-automatic-backups.md
+++ b/iis/publish/using-web-deploy/web-deploy-automatic-backups.md
@@ -47,6 +47,7 @@ Backups can either be enabled globally on the server so that all sites can take 
 The PowerShell script to configure the Backup feature at the server level can be found under `%programfiles%\IIS\Microsoft Web Deploy V3\scripts\BackupScripts.ps1`. To load it, simply navigate to that directory in PowerShell and run:
 
 [!code-console[Main](web-deploy-automatic-backups/samples/sample2.cmd)]
+(notice the single period sign with a space after).
 
 This will load the following functions into the session that you can use to configure backups.
 

--- a/iis/publish/using-web-deploy/web-deploy-automatic-backups/samples/sample2.cmd
+++ b/iis/publish/using-web-deploy/web-deploy-automatic-backups/samples/sample2.cmd
@@ -1,1 +1,1 @@
-..\BackupScripts.ps1
+. .\BackupScripts.ps1


### PR DESCRIPTION
To run the command described at iis/publish/using-web-deploy/web-deploy-automatic-backups/samples/sample2.cmd, it is necessary to add a space between the dots:
". .\BackupScripts.ps1", and not like "..\BackupScripts.ps1".
Also to make it clear I added a note on the page that refers to this script.