### PR TITLE
fix: MD023/heading-start-left/header-start-left

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -9,7 +9,6 @@
     "MD013": false,
     "MD020": false,
     "MD022": false,
-    "MD023": false,
     "MD024": false,
     "MD025": {
         "front_matter_title": ""

--- a/iis/configuration/system.applicationHost/index.md
+++ b/iis/configuration/system.applicationHost/index.md
@@ -7,7 +7,7 @@ ms.assetid: e809012e-b83b-41c3-bc1d-7c479e29f622
 msc.legacyurl: /configreference/system.applicationhost
 msc.type: config
 ---
- &lt;system.applicationHost&gt;
+&lt;system.applicationHost&gt;
 ====================
 <a id="001"></a>
 ## Overview

--- a/iis/configuration/system.applicationHost/index.md
+++ b/iis/configuration/system.applicationHost/index.md
@@ -7,8 +7,7 @@ ms.assetid: e809012e-b83b-41c3-bc1d-7c479e29f622
 msc.legacyurl: /configreference/system.applicationhost
 msc.type: config
 ---
-&lt;system.applicationHost&gt;
-====================
+# &lt;system.applicationHost&gt;
 <a id="001"></a>
 ## Overview
 

--- a/iis/configuration/system.ftpServer/index.md
+++ b/iis/configuration/system.ftpServer/index.md
@@ -7,8 +7,7 @@ ms.assetid: e6d08507-d023-47f5-9359-53bfb1183953
 msc.legacyurl: /configreference/system.ftpserver
 msc.type: config
 ---
-&lt;system.ftpServer&gt;
-====================
+# &lt;system.ftpServer&gt;
 <a id="001"></a>
 ## Overview
 

--- a/iis/configuration/system.ftpServer/index.md
+++ b/iis/configuration/system.ftpServer/index.md
@@ -7,7 +7,7 @@ ms.assetid: e6d08507-d023-47f5-9359-53bfb1183953
 msc.legacyurl: /configreference/system.ftpserver
 msc.type: config
 ---
- &lt;system.ftpServer&gt;
+&lt;system.ftpServer&gt;
 ====================
 <a id="001"></a>
 ## Overview


### PR DESCRIPTION

Headings must start at the beginning of the line