### PR TITLE
REQUEST_URI documentation incorrect

### DIFF
--- a/iis/web-dev-reference/server-variables.md
+++ b/iis/web-dev-reference/server-variables.md
@@ -67,7 +67,7 @@ URL rewrite rules can be used to set custom server variables.
 | REQUEST_FILENAME      | The physical path for the current request. |
 | REQUEST_FLAGS         | The Flags of [HTTP_REQUEST](https://docs.microsoft.com/en-us/windows/desktop/api/http/ns-http-_http_request_v1).<br/>For example, the `HTTP_REQUEST_FLAG_HTTP2` flag will be set for HTTP/2 requests. |
 | REQUEST_METHOD        | The method used to make the request. |
-| REQUEST_URI           | The path-absolute part of the URI.<br/>For example `https://contoso.com:8042/over/there?name=ferret` would return `/over/there` |
+| REQUEST_URI           | The path-absolute part of the URI.<br/>For example `https://contoso.com:8042/over/there?name=ferret` would return `contoso.com:8042/over/there?name=ferret` |
 | SCRIPT_FILENAME       | The physical path of the current request. |
 | SCRIPT_NAME           | A virtual path to the script being executed. |
 | SCRIPT_TRANSLATED     | The [extended-length path](https://msdn.microsoft.com/library/aa365247(VS.85).aspx#maxpath) to the requested file (prefixed with `\\?\`). |


### PR DESCRIPTION
It seems that the documentation regarding IIS Server Variables is relatively old and contains at least one issue:

REQUEST_URI | The path-absolute part of the URI.For example `https://contoso.com:8042/over/there?name=ferret` would return `/over/there`
-- | --

Encountering an issue and seeing a similar one: https://stackoverflow.com/questions/48457010/iis-url-rewrite-module-repeats-query-string