### PR TITLE
Fixed broken directory syntax.

### DIFF
--- a/iis/publish/using-the-ftp-service/configuring-ftp-user-isolation-in-iis-7.md
+++ b/iis/publish/using-the-ftp-service/configuring-ftp-user-isolation-in-iis-7.md
@@ -236,9 +236,9 @@ To create home directories for each user, you first need to create a virtual or 
 | User Account Types | Physical Home Directory Syntax |
 | --- | --- |
 | Anonymous users | %FtpRoot%\LocalUser\Public |
-| Local Windows user accounts (requires basic authentication) | %FtpRoot%\LocalUser\%UserName% |
-| Windows domain accounts (requires basic authentication) | %FtpRoot%\%UserDomain%\%UserName% |
-| IIS Manager or ASP.NET custom authentication user accounts | %FtpRoot%\LocalUser\%UserName% |
+| Local Windows user accounts (requires basic authentication) | %FtpRoot%\LocalUser\\%UserName% |
+| Windows domain accounts (requires basic authentication) | %FtpRoot%\\%UserDomain%\\%UserName% |
+| IIS Manager or ASP.NET custom authentication user accounts | %FtpRoot%\LocalUser\\%UserName% |
 
 > [!NOTE]
 > In the above table, %FtpRoot% is the root directory for your FTP site; for example, `C:\Inetpub\Ftproot`.


### PR DESCRIPTION
After converting to Markdown, `/%` becomes `%`, so such must be manually fixed.