### PR TITLE
Change sc to sc.exe in sample command

### DIFF
--- a/iis/manage/remote-administration/remote-administration-for-iis-manager/samples/sample3.cmd
+++ b/iis/manage/remote-administration/remote-administration-for-iis-manager/samples/sample3.cmd
@@ -1,1 +1,1 @@
-sc config WMSVC start= auto
+sc.exe config WMSVC start= auto


### PR DESCRIPTION
Because sc is an alias for Set-Content in PowerShell, you need to write sc.exe