### PR TITLE
Update IHttpContextDisableNotifications.cpp

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_IIS/IIS7/IHttpContextDisableNotifications/cpp/IHttpContextDisableNotifications.cpp
+++ b/samples/snippets/cpp/VS_Snippets_IIS/IIS7/IHttpContextDisableNotifications/cpp/IHttpContextDisableNotifications.cpp
@@ -34,7 +34,7 @@ public:
 
         // Specify which notifications to disable.
         // (Defined in the Httpserv.h file.)
-        pHttpContext->DisableNotifications(0,RQ_BEGIN_REQUEST);
+        pHttpContext->DisableNotifications(RQ_BEGIN_REQUEST, 0);
 
         // Return processing to the pipeline.
         return RQ_NOTIFICATION_CONTINUE;


### PR DESCRIPTION
Fixed the order of parameters of pHttpContext->DisableNotifications(). 
From:
 (0, RQ_BEGIN_REQUEST)
To:
 (RQ_BEGIN_REQUEST, 0)