### PR TITLE
Added a note.

### DIFF
--- a/iis/configuration/system.webServer/httpErrors/error.md
+++ b/iis/configuration/system.webServer/httpErrors/error.md
@@ -63,6 +63,9 @@ The `<error>` element of the `<httpErrors>` collection is included in the defaul
   
     > [!NOTE]
     > If you select **Execute a URL on this site**, the path must be a relative path. If you select **Respond with a 302 redirect**, the URL must be an absolute URL.
+    
+    > [!NOTE]
+    > You cannot customize the following HTTP errors: 400, 403.9, 411, 414, 500, 500.11, 500.14, 500.15, 501, 503, and 505. 
 
 ## Configuration
 

--- a/iis/configuration/system.webServer/httpErrors/error.md
+++ b/iis/configuration/system.webServer/httpErrors/error.md
@@ -65,7 +65,7 @@ The `<error>` element of the `<httpErrors>` collection is included in the defaul
     > If you select **Execute a URL on this site**, the path must be a relative path. If you select **Respond with a 302 redirect**, the URL must be an absolute URL.
     
     > [!NOTE]
-    > You cannot customize the following HTTP errors: 400, 403.9, 411, 414, 500, 500.11, 500.14, 500.15, 501, 503, and 505. 
+    > The following HTTP errors can't be customized: 400, 403.9, 411, 414, 500, 500.11, 500.14, 500.15, 501, 503, and 505. 
 
 ## Configuration
 


### PR DESCRIPTION
It is not obvious that some error codes cannot be customized when that piece of information is solely in https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc753103(v=ws.10)

By replicating the same note here, it can save customers some time.