### PR TITLE
fix:  Remove trailing brace in literal links

### DIFF
--- a/iis/troubleshoot/performance-issues/troubleshooting-iis-performance-issues-or-application-errors-using-logparser.md
+++ b/iis/troubleshoot/performance-issues/troubleshooting-iis-performance-issues-or-application-errors-using-logparser.md
@@ -13,9 +13,9 @@ by [Benjamin Perkins](https://twitter.com/csharpguitar)
 
 ## Tools and knowledge used in this Troubleshooter
 
-- Microsoft LogParser (<https://www.microsoft.com/download/details.aspx?id=24659)>)
+- Microsoft LogParser (<https://www.microsoft.com/download/details.aspx?id=24659>)
 - Command Prompt
-- A basic knowledge of IIS HTTP Status Codes is helpful (<https://support.microsoft.com/kb/943891)>)
+- A basic knowledge of IIS HTTP Status Codes is helpful (<https://support.microsoft.com/kb/943891>)
 - A basic knowledge of SQL queries is helpful
 
 ## Overview


### PR DESCRIPTION

Closes #445