### PR TITLE
Update web-platform-installer-direct-downloads.md

### DIFF
--- a/iis/install/web-platform-installer/web-platform-installer-direct-downloads.md
+++ b/iis/install/web-platform-installer/web-platform-installer-direct-downloads.md
@@ -14,9 +14,9 @@ by [Chris Sfanos](https://github.com/chrissfanos)
 **WebPI Direct Download Links**  
   
  In some cases, it may be helpful to be able to download the Web Platform Installer directly vs using the launcher to get started. Below are the links for the current version (WebPI 5.1).  
-  
-**WebPI 5.1**  
  
+**WebPI 5.1**
+
  x86: [WebPI 5.1 x86 MSI] (https://go.microsoft.com/fwlink/?LinkId=287165)
  
  x64: [WebPI 5.1 x64 MSI] (https://go.microsoft.com/fwlink/?LinkId=287166)

--- a/iis/install/web-platform-installer/web-platform-installer-direct-downloads.md
+++ b/iis/install/web-platform-installer/web-platform-installer-direct-downloads.md
@@ -20,5 +20,3 @@ by [Chris Sfanos](https://github.com/chrissfanos)
  x86: [WebPI 5.1 x86 MSI] (https://go.microsoft.com/fwlink/?LinkId=287165)
  
  x64: [WebPI 5.1 x64 MSI] (https://go.microsoft.com/fwlink/?LinkId=287166)
-
-

--- a/iis/install/web-platform-installer/web-platform-installer-direct-downloads.md
+++ b/iis/install/web-platform-installer/web-platform-installer-direct-downloads.md
@@ -13,16 +13,12 @@ by [Chris Sfanos](https://github.com/chrissfanos)
 
 **WebPI Direct Download Links**  
   
- In some cases, it may be helpful to be able to download the Web Platform Installer directly vs using the launcher to get started. Below are the links for the current version (WebPI 5.0) and the previous version (WebPI 4.6)   
+ In some cases, it may be helpful to be able to download the Web Platform Installer directly vs using the launcher to get started. Below are the links for the current version (WebPI 5.1).  
   
-**WebPI 5.0**  
-  
- x86: [https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller\_x86\_en-US.msi](https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_x86_en-US.msi)  
-  
- x64: [https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller\_amd64\_en-US.msi](https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi)  
-  
-**WebPI 4.6**  
-  
- x86: [https://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller\_x86\_en-US.msi](https://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_x86_en-US.msi)  
-  
- x64: [https://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller\_amd64\_en-US.msi](https://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_amd64_en-US.msi)
+**WebPI 5.1**  
+ 
+ x86: [WebPI 5.1 x86 MSI] (https://go.microsoft.com/fwlink/?LinkId=287165)
+ 
+ x64: [WebPI 5.1 x64 MSI] (https://go.microsoft.com/fwlink/?LinkId=287166)
+
+


### PR DESCRIPTION
This page was way out of date - removing 5.0 and 4.6 links and only updating to 5.1.  Also using redirects vs direct download locations