### PR TITLE
Add docs for LoadManagedRuntime

### DIFF
--- a/iis/web-development-reference/native-code-api-reference/TOC.yml
+++ b/iis/web-development-reference/native-code-api-reference/TOC.yml
@@ -692,7 +692,13 @@
           - name: IWpfSettings::GetStringProperty Method
             href: iwpfsettings-getstringproperty-method.md
           - name: IWpfSettings::GetUlonglongProperty Method
-            href: iwpfsettings-getulonglongproperty-method.md
+            href: iwpfsettings-getulonglongproperty-method.md    
+    - name: Managed Runtime Loader API Reference
+      items:
+      - name: LoadManagedRuntime Function
+        href: loadmanagedruntime-function.md
+      - name: LoadManagedRuntimeEx Function
+        href: loadmanagedruntimeex-function.md
   - name: Native-Code Extensibility API Reference
     href: native-code-extensibility-api-reference.md
     items:

--- a/iis/web-development-reference/native-code-api-reference/loadmanagedruntime-function.md
+++ b/iis/web-development-reference/native-code-api-reference/loadmanagedruntime-function.md
@@ -1,0 +1,46 @@
+---
+title: LoadManagedRuntime function
+ms.date: 02/03/2021
+api_name:
+  - LoadManagedRuntime
+api_location:
+  - "webengine4.dll"
+api_type:
+  - "DLLExport"
+topic_type:
+  - "apiref"
+---
+# LoadManagedRuntime function
+
+Loads a specified version of the common language runtime (CLR) into a process.
+
+## Syntax
+
+```cpp
+HRESULT __stdcall
+LoadManagedRuntime(
+        _In_ PCWSTR pwszRuntimeVersion,
+        __deref_out IUnknown ** ppManagedRuntimeHost)
+```
+
+### Parameters
+
+`pwszRuntimeVersion`\
+[in] A string that describes the version of the CLR you want to load. A version number in the .NET Framework consists of four parts separated by periods: *major.minor.build.revision*. The string must start with the character "v" followed by the first three parts of the version number (for example, "v4.0.30319").
+
+`ppManagedRuntimeHost`\
+[out] An interface pointer to the version of the runtime that was loaded.
+
+## Requirements
+
+|Type|Description|
+|----------|-----------------|
+|Client|-   IIS 7.5 on Windows 7|
+|Server|-   IIS 7.5 on Windows Server 2008 R2|
+|Product|-   IIS 7.5<br />-   [!INCLUDE[iisexp75](../../web-development-reference/native-code-api-reference/includes/iisexp75-md.md)]|
+|Assembly|webengine4.dll|
+
+## See also
+
+- [ASP.NET performance: Managed runtime loader](https://devblogs.microsoft.com/aspnet/asp-net-performance-managed-runtime-loader/)
+- [CorBindToRuntimeHost Function](/dotnet/framework/unmanaged-api/hosting/corbindtoruntimehost-function)

--- a/iis/web-development-reference/native-code-api-reference/loadmanagedruntimeex-function.md
+++ b/iis/web-development-reference/native-code-api-reference/loadmanagedruntimeex-function.md
@@ -1,0 +1,50 @@
+---
+title: LoadManagedRuntimeEx function
+ms.date: 02/03/2021
+api_name:
+  - LoadManagedRuntimeEx
+api_location:
+  - "webengine4.dll"
+api_type:
+  - "DLLExport"
+topic_type:
+  - "apiref"
+---
+# LoadManagedRuntimeEx function
+
+Loads a specified version of the common language runtime (CLR) into a process.
+
+## Syntax
+
+```cpp
+HRESULT __stdcall
+LoadManagedRuntimeEx(
+        _In_ PCWSTR pwszRuntimeVersion,
+        _In_ PCWSTR pszClrConfigFile,
+        __deref_out IUnknown ** ppManagedRuntimeHost)
+```
+
+### Parameters
+
+`pwszRuntimeVersion`\
+[in] A string that describes the version of the CLR you want to load. A version number in the .NET Framework consists of four parts separated by periods: *major.minor.build.revision*. The string must start with the character "v" followed by the first three parts of the version number (for example, "v4.0.30319").
+
+`pszClrConfigFile`\
+[in] The name of a host configuration file that specifies the version of the CLR to load. If the file name does not include a fully qualified path, the file is assumed to be in the same directory as the executable that is making the call.
+
+`ppManagedRuntimeHost`\
+[out] An interface pointer to the version of the runtime that was loaded.
+
+## Requirements
+
+|Type|Description|
+|----------|-----------------|
+|Client|-   IIS 7.5 on Windows 7<br />-   IIS 8.0 on Windows 8<br />|
+|Server|-   IIS 7.5 on Windows Server 2008 R2<br />-   IIS 8.0 on Windows Server 2012<br />|
+|Product|-   IIS 7.5, IIS 8.0<br />-   [!INCLUDE[iisexp75](../../web-development-reference/native-code-api-reference/includes/iisexp75-md.md)], [!INCLUDE[iisexp80](../../web-development-reference/native-code-api-reference/includes/iisexp80-md.md)]|
+|Assembly|webengine4.dll|
+
+## See also
+
+- [ASP.NET performance: Managed runtime loader](https://devblogs.microsoft.com/aspnet/asp-net-performance-managed-runtime-loader/)
+- [CorBindToRuntimeHost Function](/dotnet/framework/unmanaged-api/hosting/corbindtoruntimehost-function)

--- a/iis/web-development-reference/native-code-api-reference/native-code-architecture-api-reference.md
+++ b/iis/web-development-reference/native-code-api-reference/native-code-architecture-api-reference.md
@@ -4,21 +4,25 @@ ms.date: "10/07/2016"
 ms.assetid: 6cb22f31-7ef6-4fe6-b686-36b04d8c4f52
 ---
 # Native-Code Architecture API Reference
+
 This section discusses the APIs that define the core architecture for IIS.  
   
-## In This Section  
- [Hosted Web Core API Reference](../../web-development-reference/native-code-api-reference/hosted-web-core-api-reference.md)  
- Describes the functions that developers can use to host Web pages with the Hosted Web Core.  
+## In This Section
+
+[Hosted Web Core API Reference](../../web-development-reference/native-code-api-reference/hosted-web-core-api-reference.md)  
+Describes the functions that developers can use to host Web pages with the Hosted Web Core.  
   
- [Listener Adapter API Reference](../../web-development-reference/native-code-api-reference/listener-adapter-api-reference.md)  
- Describes the functions and structures that enable listener adapters to communicate with the Windows Process Activation Service (WAS).  
+[Listener Adapter API Reference](../../web-development-reference/native-code-api-reference/listener-adapter-api-reference.md)  
+Describes the functions and structures that enable listener adapters to communicate with the Windows Process Activation Service (WAS).  
   
- [Windows Process Activation Service API Reference](../../web-development-reference/native-code-api-reference/windows-process-activation-service-api-reference.md)  
- Describes the functions and interfaces that enable process activation and monitoring of applications, listener channels, and listener adaptors.  
+[Windows Process Activation Service API Reference](../../web-development-reference/native-code-api-reference/windows-process-activation-service-api-reference.md)  
+Describes the functions and interfaces that enable process activation and monitoring of applications, listener channels, and listener adaptors.  
   
- [Worker Process Framework API Reference](../../web-development-reference/native-code-api-reference/worker-process-framework-api-reference.md)  
- Describes the API that enables worker processes and protocol managers to exchange data with other protocol managers.  
-  
+[Worker Process Framework API Reference](../../web-development-reference/native-code-api-reference/worker-process-framework-api-reference.md)  
+Describes the API that enables worker processes and protocol managers to exchange data with other protocol managers.  
+
+[Managed Runtime Loader API Reference](loadmanagedruntime-function.md)
+
 ## See Also  
  [Native-Code API Reference](../../web-development-reference/native-code-api-reference/native-code-api-reference.md)   
  [Native-Code Administration API Reference](../../web-development-reference/native-code-api-reference/native-code-administration-api-reference.md)   


### PR DESCRIPTION
For APIScan compliance.

Please check TOC placement, IIS versions, header file.

[Preview link](https://review.docs.microsoft.com/en-us/iis/web-development-reference/native-code-api-reference/loadmanagedruntime-function?branch=pr-en-us-546).