### PR TITLE
Move WWAG retirement blurb

### DIFF
--- a/iis/develop/windows-web-application-gallery/azure-app-gallery-faq.md
+++ b/iis/develop/windows-web-application-gallery/azure-app-gallery-faq.md
@@ -7,12 +7,12 @@ ms.assetid: a4555019-dd6e-41b4-831c-1711760031f5
 msc.legacyurl: /learn/develop/windows-web-application-gallery/azure-app-gallery-faq
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Azure App Gallery FAQ
 
 by [Sunitha Muthukrishna](https://github.com/SunBuild)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 ## Introduction
 

--- a/iis/develop/windows-web-application-gallery/blogengine-net-sample-files.md
+++ b/iis/develop/windows-web-application-gallery/blogengine-net-sample-files.md
@@ -7,12 +7,12 @@ ms.assetid: 1f41da75-1fde-433e-af1e-d29f8b187478
 msc.legacyurl: /learn/develop/windows-web-application-gallery/blogengine-net-sample-files
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Blogengine .NET Sample files
 
 by Steve Jacobson
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 This is a set of sample files you could use with Blogengine .NET and the Web Deployment tool for deploying it on IIS. The `manifest.xml` and `parameters.xml` here are used to set the appropriate permissions and deploy the files to a web server . This application uses a file data store within App\_Data directory and hence requires that this directory have ReadAndExecute,Write,Delete permissions .
 

--- a/iis/develop/windows-web-application-gallery/database-notes-for-packaging-applications-for-use-with-the-web-application-gallery.md
+++ b/iis/develop/windows-web-application-gallery/database-notes-for-packaging-applications-for-use-with-the-web-application-gallery.md
@@ -7,12 +7,12 @@ ms.assetid: 9e5f2ff1-7a54-45f0-8197-7dd783154e41
 msc.legacyurl: /learn/develop/windows-web-application-gallery/database-notes-for-packaging-applications-for-use-with-the-web-application-gallery
 msc.type: authoredcontent
 ---
-> [!NOTE] 
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Database Notes for packaging applications for the Web Application Gallery
 
 by Steve Jacobson
+
+> [!NOTE] 
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 The database providers for the Web Deployment Tool (WebDeploy) give application developers a great deal of flexibility in setting up databases as part of their application installs. Outside of the Gallery, applications have a variety of methods for setting up databases, tables, users, and starting data:
 

--- a/iis/develop/windows-web-application-gallery/frequently-asked-questions.md
+++ b/iis/develop/windows-web-application-gallery/frequently-asked-questions.md
@@ -7,12 +7,12 @@ ms.assetid: 0fda743d-d99e-4172-8e4e-ec1d448281b8
 msc.legacyurl: /learn/develop/windows-web-application-gallery/frequently-asked-questions
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Windows Web App Gallery FAQ
 
 by [Sunitha Muthukrishna](https://github.com/SunBuild)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 ## Frequently Asked Questions
 

--- a/iis/develop/windows-web-application-gallery/gallery-server-pro-sample-files.md
+++ b/iis/develop/windows-web-application-gallery/gallery-server-pro-sample-files.md
@@ -7,12 +7,12 @@ ms.assetid: a0991296-04e5-4a8a-8d67-8a79d6754405
 msc.legacyurl: /learn/develop/windows-web-application-gallery/gallery-server-pro-sample-files
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Gallery Server Pro sample files
 
 by Steve Jacobson
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 This is a set of sample files you could use with Gallery Server Pro and the Web Deployment tool for deploying Gallery Server Pro on IIS. You can include a custom `_SqlMembership.txt` file to parameterize the Application's admin username and password that can be used by the application to setup the application administrator credentials.  
   

--- a/iis/develop/windows-web-application-gallery/how-to-create-an-app-package-supporting-both-sql-server-and-mysql.md
+++ b/iis/develop/windows-web-application-gallery/how-to-create-an-app-package-supporting-both-sql-server-and-mysql.md
@@ -7,12 +7,12 @@ ms.assetid: 76946c02-3b19-43ad-b13d-3b914ab11c54
 msc.legacyurl: /learn/develop/windows-web-application-gallery/how-to-create-an-app-package-supporting-both-sql-server-and-mysql
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # How to Create an App Package Supporting both SQL Server and MySQL
 
 by [Sunitha Muthukrishna](https://github.com/SunBuild)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 Applications that currently support MySQL as their main DBMS can also support Microsoft SQL Server. [The SQL Server Driver for PHP](https://docs.microsoft.com/previous-versions/sql/sql-server-2005/cc296172(v=sql.90)) is available to PHP developers, it is a cost-effective and efficient solution for supporting SQL Server from within PHP applications. This article provides the steps needed for creating a Web Deployment package to install an application that supports both SQL Server and MySQL.
 

--- a/iis/develop/windows-web-application-gallery/integrate-the-windows-web-application-gallery-into-a-control-panel.md
+++ b/iis/develop/windows-web-application-gallery/integrate-the-windows-web-application-gallery-into-a-control-panel.md
@@ -7,12 +7,12 @@ ms.assetid: 18743857-2074-4bed-84d6-2ffab07a5ab7
 msc.legacyurl: /learn/develop/windows-web-application-gallery/integrate-the-windows-web-application-gallery-into-a-control-panel
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Integrate the Windows Web Application Gallery into a Control Panel
 
 by IIS Team
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 ## Introduction
 

--- a/iis/develop/windows-web-application-gallery/introducing-the-windows-web-application-gallery.md
+++ b/iis/develop/windows-web-application-gallery/introducing-the-windows-web-application-gallery.md
@@ -7,12 +7,12 @@ ms.assetid: a6fef702-77c2-4c2c-963b-c8c361c37fe0
 msc.legacyurl: /learn/develop/windows-web-application-gallery/introducing-the-windows-web-application-gallery
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Introducing the Windows Web Application Gallery
 
 by [Chris Sfanos](https://github.com/chrissfanos)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 The [Windows Web Application Gallery](https://www.microsoft.com/web/gallery) makes it easy to explore, discover and install popular community ASP.Net and PHP applications on Windows. Users can browse and view applications for different types of Web sites, ranging from photo galleries to blogs to ecommerce sites.
 

--- a/iis/develop/windows-web-application-gallery/joomla-sample-files.md
+++ b/iis/develop/windows-web-application-gallery/joomla-sample-files.md
@@ -7,12 +7,12 @@ ms.assetid: d9957c2a-8f3d-4a3b-b9e9-d42eabf54b7a
 msc.legacyurl: /learn/develop/windows-web-application-gallery/joomla-sample-files
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Joomla! Sample files
 
 by Steve Jacobson
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 This is a set of sample files you could use with Joomla! and the Web Deployment tool for deploying Joomla on IIS. The files are annotated with comments that explain specific lines in the files you'll need to customize for your configuration.
 

--- a/iis/develop/windows-web-application-gallery/mediawiki-sample-files.md
+++ b/iis/develop/windows-web-application-gallery/mediawiki-sample-files.md
@@ -7,12 +7,12 @@ ms.assetid: 052e4fa7-82d5-41f8-8c22-a37428f6de27
 msc.legacyurl: /learn/develop/windows-web-application-gallery/mediawiki-sample-files
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # MediaWiki Sample Files
 
 by Steve Jacobson
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 This is a set of sample files you could use with MediaWiki and the Web Deployment tool for deploying MediaWiki on IIS. The files are annotated with comments that explain specific lines in the files you'll need to customize for your configuration.
 

--- a/iis/develop/windows-web-application-gallery/package-an-application-for-the-windows-web-application-gallery.md
+++ b/iis/develop/windows-web-application-gallery/package-an-application-for-the-windows-web-application-gallery.md
@@ -7,12 +7,12 @@ ms.assetid: d88db0b1-a662-47a4-8978-ae8a4042ea2f
 msc.legacyurl: /learn/develop/windows-web-application-gallery/package-an-application-for-the-windows-web-application-gallery
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Package an Application for the Windows Web Application Gallery
 
 by IIS Team
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 ## Introduction
 

--- a/iis/develop/windows-web-application-gallery/reference-for-the-web-application-package.md
+++ b/iis/develop/windows-web-application-gallery/reference-for-the-web-application-package.md
@@ -7,12 +7,12 @@ ms.assetid: d0b0d1dc-ce47-409b-8dec-4153f08f483e
 msc.legacyurl: /learn/develop/windows-web-application-gallery/reference-for-the-web-application-package
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Reference for the Web Application Package
 
 by Tali Smith
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 Every application in the Web Application Gallery has at least two XML files that enable the Web Platform Installer (Web PI) to use the Web Deployment Tool (WDT) to deploy the application on Windows® operating systems. These files are the Manifest.xml and Parameters.xml files. In addition, many applications add a SQL script to be run by the WDT as part of the pre-setup installation. PHP applications also include a Web.config file.
 

--- a/iis/develop/windows-web-application-gallery/testing-a-web-application-zip-package-for-inclusion-with-the-web-application-gallery.md
+++ b/iis/develop/windows-web-application-gallery/testing-a-web-application-zip-package-for-inclusion-with-the-web-application-gallery.md
@@ -7,12 +7,12 @@ ms.assetid: 6f721a96-8210-4e2a-a110-09103f8f0b98
 msc.legacyurl: /learn/develop/windows-web-application-gallery/testing-a-web-application-zip-package-for-inclusion-with-the-web-application-gallery
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Testing a Zip Package for Inclusion with the Web Application Gallery
 
 by [Mai-lan Tomsen Bukovec](https://twitter.com/mailant)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 The [Web Application Gallery](https://www.microsoft.com/web/gallery) makes it easy for Windows users to find and deploy a free open source, community application onto a computer running Windows XP or later. To learn more about how to build Web Deploy support for a zip package so that the application can be included in the Web Application Gallery, read the [Package An Application for the Web Application Gallery](package-an-application-for-the-windows-web-application-gallery.md) guide or view the [Adding Web Deployment Tool Support to Community Application ZIP Packages videocast](https://blogs.iis.net/mailant/archive/2009/05/04/real-world-iis-adding-web-deployment-tool.aspx). Once you have build Web Application Gallery integration for your zip package, you can test the Web Application Integration using [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx).
 

--- a/iis/develop/windows-web-application-gallery/umbraco-cms-sample-files.md
+++ b/iis/develop/windows-web-application-gallery/umbraco-cms-sample-files.md
@@ -7,12 +7,12 @@ ms.assetid: 1114e4dc-e2ea-4932-a616-745230baa1a8
 msc.legacyurl: /learn/develop/windows-web-application-gallery/umbraco-cms-sample-files
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Umbraco CMS Sample files
 
 by [Sunitha Muthukrishna](https://github.com/SunBuild)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 This is a set of sample files you could use with Umbraco CMS 5 and the Web Deployment tool for deploying Umbraco against a SQL Express/SQL Azure database or SQL CE database.
 

--- a/iis/develop/windows-web-application-gallery/using-the-microsoft-web-platform-installer-badge.md
+++ b/iis/develop/windows-web-application-gallery/using-the-microsoft-web-platform-installer-badge.md
@@ -7,12 +7,12 @@ ms.assetid: e4113e68-c5a0-4cea-b4f2-ecb0397e78fa
 msc.legacyurl: /learn/develop/windows-web-application-gallery/using-the-microsoft-web-platform-installer-badge
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Using the Microsoft Web Platform Installer Badge
 
 by Steve Jacobson
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 Developers of applications have the ability to provide a link on their sites which will be able to launch the Web Platform Installer with their application and all prerequisites ready to install. To take advantage of this feature, developers should link to the badge in this document.
 

--- a/iis/develop/windows-web-application-gallery/windows-web-application-gallery-known-issues.md
+++ b/iis/develop/windows-web-application-gallery/windows-web-application-gallery-known-issues.md
@@ -7,11 +7,11 @@ ms.assetid: 9ac68e1c-b377-4696-bde0-c44fe46750b5
 msc.legacyurl: /learn/develop/windows-web-application-gallery/windows-web-application-gallery-known-issues
 msc.type: authoredcontent
 ---
-> [!NOTE]> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Windows Web Application Gallery: Known Issues
 
 by IIS Team
+
+> [!NOTE]> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 ## Introduction
 

--- a/iis/develop/windows-web-application-gallery/windows-web-application-gallery-link-addition-process-walkthrough.md
+++ b/iis/develop/windows-web-application-gallery/windows-web-application-gallery-link-addition-process-walkthrough.md
@@ -7,12 +7,12 @@ ms.assetid: 218769b5-1bdf-49a2-97dc-a8e6c64bd724
 msc.legacyurl: /learn/develop/windows-web-application-gallery/windows-web-application-gallery-link-addition-process-walkthrough
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Windows Web Application Gallery Link Addition Process Walkthrough
 
 by IIS Team
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 This walkthrough will guide you through the process of submitting an application to the Windows Web Application Gallery.
 

--- a/iis/develop/windows-web-application-gallery/windows-web-application-gallery-principles.md
+++ b/iis/develop/windows-web-application-gallery/windows-web-application-gallery-principles.md
@@ -7,12 +7,12 @@ ms.assetid: c11dcbc8-faae-4bab-89fb-998e409440d1
 msc.legacyurl: /learn/develop/windows-web-application-gallery/windows-web-application-gallery-principles
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
-
 # Windows Web Application Gallery Principles
 
 by [Chris Sfanos](https://github.com/chrissfanos)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission.
 
 The [Windows Web Application Gallery](https://www.microsoft.com/web/gallery) makes it easy to explore, discover and install popular community ASP.Net and PHP applications on Windows. Users can browse and view applications for different types of Web sites, ranging from photo galleries to blogs to ecommerce sites. When an application is accepted by the Web Application Gallery, the application is added to the Web Application Gallery ATOM feed. The ATOM feed is consumed by the Web Application Gallery itself, Web Platform Installer, IIS Manager, and participating Hosting Control Panels.
 

--- a/iis/develop/windows-web-application-gallery/wordpress-sample-files.md
+++ b/iis/develop/windows-web-application-gallery/wordpress-sample-files.md
@@ -7,12 +7,12 @@ ms.assetid: 54c8b691-3b23-4af5-998e-93fc8484d262
 msc.legacyurl: /learn/develop/windows-web-application-gallery/wordpress-sample-files
 msc.type: authoredcontent
 ---
-> [!NOTE]
-> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission. 
-
 # WordPress Sample files
 
 by [Sunitha Muthukrishna](https://github.com/SunBuild)
+
+> [!NOTE]
+> The Windows Web Application Gallery (WWAG) is being retired on July 1, 2021. We are no longer taking submissions via the Submission Portal. Please contact webpi@microsoft.com to make updates to your existing submission. 
 
 This is a set of sample files you could use with Wordpress and the Web Deployment tool for deploying Wordpress onto IIS. The files are annotated with comments that explain specific lines in the files you'll need to customize for your configuration.
 


### PR DESCRIPTION
With my last PR I placed the blurb above the H1, which is not permitted.  (refer failures in the [Build report](https://opbuilduserstoragepublic.blob.core.windows.net/report/2021%5C4%5C22%5C90f071cf-c002-b629-5e11-5bc968bb67ca%5CPullRequest%5C202104221931287959-556%5Cworkflow_report.html?sv=2016-05-31&sr=b&sig=F0CPhmfGWgnbhYsAHGlq7RCWktueQ5oAm%2FPWWfwlr8I%3D&st=2021-04-22T19%3A27%3A44Z&se=2021-05-23T19%3A32%3A44Z&sp=r))

This PR moves the blurb below the H1.