### PR TITLE
fix  typo #580

### DIFF
--- a/iis/configuration/system.ftpServer/security/authentication/index/samples/sample1.xml
+++ b/iis/configuration/system.ftpServer/security/authentication/index/samples/sample1.xml
@@ -1,7 +1,7 @@
 <system.ftpServer>
    <security>
-      <Authentication>
+      <authentication>
          <denyByFailure enabled="true" maxFailure="5" entryExpiration="00:00:45" loggingOnlyMode="false" />
-      </Authentication>
+      </authentication>
    </security>
 </system.ftpServer>


### PR DESCRIPTION
I fixed a typo .

iis manager build configuration ：
https://github.com/vchy1997/vchy1997.issues/blob/646b76096793ccb7e3e122d64f69cd977cf3ec0c/iis-docs/%23580/applicationHost.config#L760-L762

use 【Authentication】 prompt：
https://github.com/vchy1997/vchy1997.issues/blob/master/iis-docs/%23580/%23580_Error.png