### PR TITLE
Updated DotNetNuke Documentation References

### DIFF
--- a/iis/publish/deploying-application-packages/dotnetnuke.md
+++ b/iis/publish/deploying-application-packages/dotnetnuke.md
@@ -15,7 +15,7 @@ by [Simon Tan](https://github.com/simtan)
 
 DotNetNuke (DNN) is an open source content management system (CMS) and application development framework for Microsoft .NET. For more information about DotNetNuke, refer to the [DNN Community](https://dnncommunity.org/) Web site. For step-by-step instructions on installing this application in an IIS environment, see the *Procedure* section of this document.
 
-> Please note, the steps listed below will install a not-current version of DNN Platform.  After following the steps below it is strongly suggested to upgrade to the current version of DNN Platform following the [Upgrade Process](https://docs.dnncommunity.org/content/getting-started/setup/upgrades/index.html).
+> ***Note***: The steps listed below will ***not*** install a current version of DNN Platform.  After following the steps below it is strongly suggested to upgrade to the current version of DNN Platform following the [Upgrade Process](https://docs.dnncommunity.org/content/getting-started/setup/upgrades/index.html).
 
 ## Requirements
 

--- a/iis/publish/deploying-application-packages/dotnetnuke.md
+++ b/iis/publish/deploying-application-packages/dotnetnuke.md
@@ -13,7 +13,9 @@ by [Simon Tan](https://github.com/simtan)
 
 ## Introduction
 
-DotNetNuke is an open source content management system (CMS) and application development framework for Microsoft .NET. For more information about DotNetNuke, refer to the [DotNetNuke](http://www.dotnetnuke.com/) Web site. For step-by-step instructions on installing this application in an IIS environment, see the *Procedure* section of this document.
+DotNetNuke (DNN) is an open source content management system (CMS) and application development framework for Microsoft .NET. For more information about DotNetNuke, refer to the [DNN Community](https://dnncommunity.org/) Web site. For step-by-step instructions on installing this application in an IIS environment, see the *Procedure* section of this document.
+
+> Please note, the steps listed below will install a not-current version of DNN Platform.  After following the steps below it is strongly suggested to upgrade to the current version of DNN Platform following the [Upgrade Process](https://docs.dnncommunity.org/content/getting-started/setup/upgrades/index.html).
 
 ## Requirements
 


### PR DESCRIPTION
Given that the DotNetNuke installation environment that is supported with deployment through the Web Platform Installer or the Web Matrix installation is an older, not-current, installation version this update makes two notes to this documentation.

1. References added to the DNN Community site which is the proper documentation for all DNN Platform (Open Source) information
2. Added a callout/quote note to draw attention to the need to upgrade after installation to the latest version of DNN, with an included link to the instructions on that upgrade process.

If this is not a proper method to make this recommended change, please let me know.  I just wanted to make sure it was noted that the installation versions as outlined in this guide SHOULD NOT be used in production without upgrades.