### PR TITLE
Update configure-smtp-e-mail-in-iis-7-and-above.md

### DIFF
--- a/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above.md
+++ b/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above.md
@@ -7,7 +7,7 @@ ms.assetid: 181c9548-33dd-4af4-88b8-0dab0fd05811
 msc.legacyurl: /learn/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above
 msc.type: authoredcontent
 ---
-# Configure SMTP E-Mail in IIS 7 and above
+# Configure SMTP E-Mail in IIS 7 and higher
 
 by Tali Smith
 

--- a/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above.md
+++ b/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure SMTP E-Mail in IIS 7"
+title: "Configure SMTP E-Mail in IIS 7 and above"
 author: rick-anderson
 description: "To send e-mail from a PHP application using the System.Net.Mail API, you must configure Simple Mail Transfer Protocol (SMTP) e-mail. Configuring e-mail servi..."
 ms.date: 11/15/2009
@@ -7,7 +7,7 @@ ms.assetid: 181c9548-33dd-4af4-88b8-0dab0fd05811
 msc.legacyurl: /learn/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above
 msc.type: authoredcontent
 ---
-# Configure SMTP E-Mail in IIS 7
+# Configure SMTP E-Mail in IIS 7 and above
 
 by Tali Smith
 

--- a/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above.md
+++ b/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure SMTP E-Mail in IIS 7 and above"
+title: "Configure SMTP E-Mail in IIS 7 and higher"
 author: rick-anderson
 description: "To send e-mail from a PHP application using the System.Net.Mail API, you must configure Simple Mail Transfer Protocol (SMTP) e-mail. Configuring e-mail servi..."
 ms.date: 11/15/2009


### PR DESCRIPTION
We need to add "and above" into the title of this article so include all of the IIS versions after IIS 7. The URL already contains this wording; it also needs to be in the title.