### PR TITLE
[BrokenLinksH2] fixing broken links

### DIFF
--- a/iis/publish/using-the-ftp-service/adding-ftp-publishing-to-a-web-site-in-iis-7.md
+++ b/iis/publish/using-the-ftp-service/adding-ftp-publishing-to-a-web-site-in-iis-7.md
@@ -40,7 +40,7 @@ The following items are required to complete the procedures in this article:
 2. The new FTP service must be installed. You can download and install the FTP service from the [https://www.iis.net/](https://www.iis.net/) web site using one of the following links: 
 
     - [FTP 7.5 for IIS 7.0 (x64)](https://go.microsoft.com/fwlink/?LinkID=143197)
-    - [FTP 7.5 for IIS 7.0 (x86)](https://go.microsoft.com/fwlink/?LinkID=143196)
+    - FTP 7.5 for IIS 7.0 (x86)
 
 <a id="01"></a>
 

--- a/iis/publish/using-the-ftp-service/adding-ftp-publishing-to-a-web-site-in-iis-7.md
+++ b/iis/publish/using-the-ftp-service/adding-ftp-publishing-to-a-web-site-in-iis-7.md
@@ -39,8 +39,8 @@ The following items are required to complete the procedures in this article:
     - The Internet Information Services Manager must be installed.
 2. The new FTP service must be installed. You can download and install the FTP service from the [https://www.iis.net/](https://www.iis.net/) web site using one of the following links: 
 
-    - [FTP 7.5 for IIS 7.0 (x64)](https://go.microsoft.com/fwlink/?LinkID=143197)
-    - FTP 7.5 for IIS 7.0 (x86)
+    - [FTP 7.5 for IIS 7.0 (x64)](https://www.iis.net/downloads/microsoft/ftp)
+    - [FTP 7.5 for IIS 7.0 (x86)](https://www.iis.net/downloads/microsoft/ftp)
 
 <a id="01"></a>
 


### PR DESCRIPTION
**Global effort to fix broken links**

@rmcmurray

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!

I've been unable to locate the x86 download anywhere on a Microsoft site.