### PR TITLE
[BULK] validation: various

### DIFF
--- a/iis/application-frameworks/install-and-configure-php-on-iis/secure-your-sql-server-database.md
+++ b/iis/application-frameworks/install-and-configure-php-on-iis/secure-your-sql-server-database.md
@@ -134,7 +134,7 @@ The following table contains information about how to use certificates with SQL 
 
 ## Application Security
 
-SQL Server security best practices include writing secure client applications. For more information about server access and SQL Server client applications, see [Developer's Guide (Database Engine)](/sql/relational-databases/database-engine-tutorials?view=sql-server-ver16).
+SQL Server security best practices include writing secure client applications. For more information about server access and SQL Server client applications, see [Developer's Guide (Database Engine)](/sql/relational-databases/database-engine-tutorials?view=sql-server-ver16&preserve-view=true).
 
 For more information about how to help secure client applications at the networking layer, see [Client Network Configuration](https://msdn.microsoft.com/library/ms190611.aspx).
 

--- a/iis/configuration/system.applicationHost/sites/site/ftpServer/security/authentication/customAuthentication/providers/add.md
+++ b/iis/configuration/system.applicationHost/sites/site/ftpServer/security/authentication/customAuthentication/providers/add.md
@@ -21,8 +21,8 @@ The main advantage of using custom authentication providers is that user account
 > [!NOTE]
 > FTP 7.0 and FTP 7.5 ship with two custom authentication providers:
 
-- ASP.NET Membership authentication: This uses an ASP.NET membership database to validate user names and passwords. For more information, see the [Configuring FTP with .NET Membership Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configuring-ftp-with-net-membership-authentication-in-iis-7) topic on Microsoft's IIS.net Web site.
-- IIS Manager authentication: This uses the IIS management user store to validate user names and passwords. For more information, see the [Configure FTP with IIS 7.0 Manager Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic Microsoft's IIS.net Web site.
+- ASP.NET Membership authentication: This uses an ASP.NET membership database to validate user names and passwords. For more information, see the [Configuring FTP with .NET Membership Authentication](/iis/publish/using-the-ftp-service/configuring-ftp-with-net-membership-authentication-in-iis-7) topic on Microsoft's IIS.net Web site.
+- IIS Manager authentication: This uses the IIS management user store to validate user names and passwords. For more information, see the [Configure FTP with IIS 7.0 Manager Authentication](/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic Microsoft's IIS.net Web site.
 
 > [!NOTE]
 > The custom authentication providers that are added to the `<customAuthentication/providers>` element must be registered in the [`<system.ftpServer/providerDefinitions>`](../../../../../../../../system.ftpserver/providerdefinitions/index.md) collection.
@@ -147,7 +147,7 @@ To support FTP publishing for your Web server, you must install the FTP service.
     [![Screenshot of F T P Authentication page displaying I I S Manager enabled.](add/_static/image14.png)](add/_static/image13.png)
 7. If desired, you can disable **Basic Authentication** or **Anonymous Authentication** by highlighting either mode and clicking **Disable** in the **Actions** pane.
 
-For additional information about how to configure IIS Manager authentication for FTP, see the [Configure FTP with IIS 7.0 Manager Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic on Microsoft's [www.iis.net/learn](https://www.iis.net/learn) Web site.
+For additional information about how to configure IIS Manager authentication for FTP, see the [Configure FTP with IIS 7.0 Manager Authentication](/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic on Microsoft's [www.iis.net/learn](https://www.iis.net/learn) Web site.
 
 * * *
 

--- a/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/authentication/customAuthentication/index.md
+++ b/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/authentication/customAuthentication/index.md
@@ -21,8 +21,8 @@ The main advantage of using custom authentication providers is that user account
 > [!NOTE]
 > FTP 7.0 and FTP 7.5 ship with two custom authentication providers:
 
-- ASP.NET Membership authentication: This uses an ASP.NET membership database to validate user names and passwords. For more information, see the [Configuring FTP with .NET Membership Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configuring-ftp-with-net-membership-authentication-in-iis-7) topic on Microsoft's IIS.net Web site.
-- IIS Manager authentication: This uses the IIS management user store to validate user names and passwords. For more information, see the [Configure FTP with IIS 7.0 Manager Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic Microsoft's IIS.net Web site.
+- ASP.NET Membership authentication: This uses an ASP.NET membership database to validate user names and passwords. For more information, see the [Configuring FTP with .NET Membership Authentication](/iis/publish/using-the-ftp-service/configuring-ftp-with-net-membership-authentication-in-iis-7) topic on Microsoft's IIS.net Web site.
+- IIS Manager authentication: This uses the IIS management user store to validate user names and passwords. For more information, see the [Configure FTP with IIS 7.0 Manager Authentication](/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic Microsoft's IIS.net Web site.
 
 > [!NOTE]
 > The custom authentication providers that are added to the `<customAuthentication/providers>` element must be registered in the [`<system.ftpServer/providerDefinitions>`](../../../../../../../system.ftpserver/providerdefinitions/index.md) collection.
@@ -147,7 +147,7 @@ To support FTP publishing for your Web server, you must install the FTP service.
     [![Screenshot that shows the F T P Authentication pane. I i s Manager Auth is enabled.](index/_static/image14.png)](index/_static/image13.png)
 7. If desired, you can disable **Basic Authentication** or **Anonymous Authentication** by highlighting either mode and clicking **Disable** in the **Actions** pane.
 
-For additional information about how to configure IIS Manager authentication for FTP, see the [Configure FTP with IIS 7.0 Manager Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic on Microsoft's [www.iis.net/learn](https://www.iis.net/learn) Web site.
+For additional information about how to configure IIS Manager authentication for FTP, see the [Configure FTP with IIS 7.0 Manager Authentication](/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic on Microsoft's [www.iis.net/learn](https://www.iis.net/learn) Web site.
 
 * * *
 

--- a/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/authentication/customAuthentication/providers/add.md
+++ b/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/authentication/customAuthentication/providers/add.md
@@ -21,8 +21,8 @@ The main advantage of using custom authentication providers is that user account
 > [!NOTE]
 > FTP 7.0 and FTP 7.5 ship with two custom authentication providers:
 
-- ASP.NET Membership authentication: This uses an ASP.NET membership database to validate user names and passwords. For more information, see the [Configuring FTP with .NET Membership Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configuring-ftp-with-net-membership-authentication-in-iis-7) topic on Microsoft's IIS.net Web site.
-- IIS Manager authentication: This uses the IIS management user store to validate user names and passwords. For more information, see the [Configure FTP with IIS 7.0 Manager Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic Microsoft's IIS.net Web site.
+- ASP.NET Membership authentication: This uses an ASP.NET membership database to validate user names and passwords. For more information, see the [Configuring FTP with .NET Membership Authentication](/iis/publish/using-the-ftp-service/configuring-ftp-with-net-membership-authentication-in-iis-7) topic on Microsoft's IIS.net Web site.
+- IIS Manager authentication: This uses the IIS management user store to validate user names and passwords. For more information, see the [Configure FTP with IIS 7.0 Manager Authentication](/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic Microsoft's IIS.net Web site.
 
 > [!NOTE]
 > The custom authentication providers that are added to the `<customAuthentication/providers>` element must be registered in the [`<system.ftpServer/providerDefinitions>`](../../../../../../../../system.ftpserver/providerdefinitions/index.md) collection.
@@ -147,7 +147,7 @@ To support FTP publishing for your Web server, you must install the FTP service.
     ![Screenshot of the F T P Authentication page showing the I I S Manager Authentication option being enabled.](add/_static/image13.png)
 7. If desired, you can disable **Basic Authentication** or **Anonymous Authentication** by highlighting either mode and clicking **Disable** in the **Actions** pane.
 
-For additional information about how to configure IIS Manager authentication for FTP, see the [Configure FTP with IIS 7.0 Manager Authentication](https://docs.microsoft.com/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic on Microsoft's [www.iis.net/learn](https://www.iis.net/learn) Web site.
+For additional information about how to configure IIS Manager authentication for FTP, see the [Configure FTP with IIS 7.0 Manager Authentication](/iis/publish/using-the-ftp-service/configure-ftp-with-iis-manager-authentication-in-iis-7) topic on Microsoft's [www.iis.net/learn](https://www.iis.net/learn) Web site.
 
 * * *
 

--- a/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/customAuthorization/index.md
+++ b/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/customAuthorization/index.md
@@ -16,7 +16,7 @@ The `<customAuthorization>` element specifies the default settings for custom au
 
 If you enable a custom authorization provider, the built-in authorization provider will not be used, and you will not be able to manually add an allow rule or a deny rule to the configuration.
 
-For information about how to create a custom provider, see [How to Use Managed Code (C#) to Create a Simple FTP Home Directory Provider](https://docs.microsoft.com/iis/develop/developing-for-ftp/how-to-use-managed-code-c-to-create-a-simple-ftp-home-directory-provider).
+For information about how to create a custom provider, see [How to Use Managed Code (C#) to Create a Simple FTP Home Directory Provider](/iis/develop/developing-for-ftp/how-to-use-managed-code-c-to-create-a-simple-ftp-home-directory-provider).
 
 <a id="002"></a>
 ## Compatibility

--- a/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/customAuthorization/provider.md
+++ b/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/security/customAuthorization/provider.md
@@ -16,7 +16,7 @@ The `<customAuthorization>` element specifies the default settings for custom au
 
 If you enable a custom authorization provider, the built-in authorization provider will not be used, and you will not be able to manually add an allow rule or a deny rule to the configuration.
 
-For information about how to create a custom provider, see [How to Use Managed Code (C#) to Create a Simple FTP Home Directory Provider](https://docs.microsoft.com/iis/develop/developing-for-ftp/how-to-use-managed-code-c-to-create-a-simple-ftp-home-directory-provider).
+For information about how to create a custom provider, see [How to Use Managed Code (C#) to Create a Simple FTP Home Directory Provider](/iis/develop/developing-for-ftp/how-to-use-managed-code-c-to-create-a-simple-ftp-home-directory-provider).
 
 <a id="002"></a>
 ## Compatibility

--- a/iis/extensions/advanced-logging-module/advanced-logging-for-iis-log-filtering.md
+++ b/iis/extensions/advanced-logging-module/advanced-logging-for-iis-log-filtering.md
@@ -133,7 +133,7 @@ To create a complex filter for a log definition that uses multiple conditions as
 5. A sub-node condition is added below the root node condition (**Condition: AND**) in the list. In the **Condition** area of the dialog box, select **OR Condition**, and then click **Add Expression**.  
     ![Screenshot of the Edit Log Definition Filter window. Condition:OR appears in the main pane. Add Expression and OR Condition are highlighted.](advanced-logging-for-iis-log-filtering/_static/image16.jpg)
 6. In the **Expression** area of the dialog box, specify the following values for the expression:  
-    ![Screenshot of the Edit Log Definition Filter window. The example expression is highlighted in the main pane. Options are highlighted in the Expression pane.](advanced-logging-for-iis-log-filtering/_static/image17.jpg)
+    ![Screenshot of Edit Log Definition Filter with the example highlighted in the main pane and options in the Expression pane.](advanced-logging-for-iis-log-filtering/_static/image17.jpg)
 
     - **Field**. Select **URI-Stem**.
     - **Operator**. Select **Equals**.

--- a/iis/extensions/configuring-application-request-routing-arr/achieving-high-availability-and-scalability-arr-and-nlb.md
+++ b/iis/extensions/configuring-application-request-routing-arr/achieving-high-availability-and-scalability-arr-and-nlb.md
@@ -120,7 +120,7 @@ The NLB configuration is divided into the following steps:
 
 1. Verify that NLB is installed on all instances of ARR servers.
 2. Go to Start &gt; All Programs &gt; Administrative Tools, and open the **Network Load Balancing Manager**.  
-    ![Screenshot of the Network Load Balancing Manager window.](achieving-high-availability-and-scalability-arr-and-nlb/_static/image16.jpg)
+    ![Screenshot of the Network Load Balancing Manager window with Network Load Balancing Clusters highlighted.](achieving-high-availability-and-scalability-arr-and-nlb/_static/image16.jpg)
 3. Right-click on **Network Load Balancing Clusters**, and then select **New Cluster**.  
     ![Screenshot of the New Cluster dialog.](achieving-high-availability-and-scalability-arr-and-nlb/_static/image18.jpg)
 4. In the New Cluster dialog box, in the Host text box, type the server address of one of the ARR servers. If there are multiple interfaces, type the server address that you want to create the NLB cluster on.  

--- a/iis/extensions/configuring-application-request-routing-arr/creating-a-forward-proxy-using-application-request-routing.md
+++ b/iis/extensions/configuring-application-request-routing-arr/creating-a-forward-proxy-using-application-request-routing.md
@@ -89,7 +89,7 @@ To enable ARR as a proxy, and to create a URL Rewrite rule to enable ARR as a fo
     - Using: Wildcards
     - Pattern: \*
 
-    ![Edit Inbound Rule](creating-a-forward-proxy-using-application-request-routing/_static/image10.jpg)
+    ![Screenshot shows the Edit Inbound Rule dialog box for Forward Proxy.](creating-a-forward-proxy-using-application-request-routing/_static/image10.jpg)
 12. Scroll down to the **Conditions** area of the **Edit Inbound Rule** dialog box, and then click **Add…**.
     ![Add Condition](creating-a-forward-proxy-using-application-request-routing/_static/image11.jpg)
 13. In the **Add Condition** dialog box, select or enter the following: 
@@ -104,7 +104,7 @@ To enable ARR as a proxy, and to create a URL Rewrite rule to enable ARR as a fo
     - Action Type: Rewrite
     - Rewrite URL: http://{C:1}/{R:0}
 
-    ![Edit Inbound Rule](creating-a-forward-proxy-using-application-request-routing/_static/image13.jpg)
+    ![Screenshot shows the Edit Inbound Rule dialog box with the Action type Rewrite and a specified Rewrite URL.](creating-a-forward-proxy-using-application-request-routing/_static/image13.jpg)
 15. In the **Actions** pane, click **Apply**. 
 
     > [!NOTE]

--- a/iis/extensions/database-manager-reference/column-allownulls-property-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/column-allownulls-property-microsoft-web-management-databasemanager.md
@@ -2,7 +2,6 @@
 title: Column.AllowNulls Property (Microsoft.Web.Management.DatabaseManager)
 description: This article contains information on syntax and permissions for the Column.AllowNulls property. There are also links to more resources.
 TOCTitle: AllowNulls Property
-description: This article explains how to get or set a value in a database column as null. It includes a detailed description and code samples for reference.
 ms:assetid: P:Microsoft.Web.Management.DatabaseManager.Column.AllowNulls
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.column.allownulls(v=VS.90)
 ms:contentKeyID: 20476640

--- a/iis/extensions/database-manager-reference/column-haschanges-method-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/column-haschanges-method-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: Column.HasChanges Method  (Microsoft.Web.Management.DatabaseManager)
+description: The Column.HasChanges method retrieves whether the column has specific changes.
 TOCTitle: HasChanges Method
 ms:assetid: M:Microsoft.Web.Management.DatabaseManager.Column.HasChanges(Microsoft.Web.Management.DatabaseManager.ColumnChanges)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.column.haschanges(v=VS.90)

--- a/iis/extensions/database-manager-reference/columndatainfo-class-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/columndatainfo-class-microsoft-web-management-databasemanager.md
@@ -2,7 +2,6 @@
 title: ColumnDataInfo Class (Microsoft.Web.Management.DatabaseManager)
 description: This article provides code syntax and lists the inheritance hierarchy for the properties of the ColumDataInfo class.
 TOCTitle: ColumnDataInfo Class
-description: "The ColumnDataInfo class represents the information about the data in a column within the database that is being managed."
 ms:assetid: T:Microsoft.Web.Management.DatabaseManager.ColumnDataInfo
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.columndatainfo(v=VS.90)
 ms:contentKeyID: 20476418

--- a/iis/extensions/database-manager-reference/columndatainfo-columnname-property-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/columndatainfo-columnname-property-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: ColumnDataInfo.ColumnName Property (Microsoft.Web.Management.DatabaseManager)
+description: The ColumnDataInfo.ColumnName property gets or sets a value that specifies the name of the database column.
 TOCTitle: ColumnName Property
 ms:assetid: P:Microsoft.Web.Management.DatabaseManager.ColumnDataInfo.ColumnName
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.columndatainfo.columnname(v=VS.90)

--- a/iis/extensions/database-manager-reference/columndatainfo-properties-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/columndatainfo-properties-microsoft-web-management-databasemanager.md
@@ -2,7 +2,6 @@
 title: ColumnDataInfo Properties (Microsoft.Web.Management.DatabaseManager)
 description: This article provides a list and description of the properties for the ColumnDataInfo class. Each one is linked to code samples.
 TOCTitle: ColumnDataInfo Properties
-description: "List of the members that are exposed by the ColumnDataInfo type. The property type, name, and description for each are provided."
 ms:assetid: Properties.T:Microsoft.Web.Management.DatabaseManager.ColumnDataInfo
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.columndatainfo_properties(v=VS.90)
 ms:contentKeyID: 20476625

--- a/iis/extensions/database-manager-reference/databaseprovider-connectionstringarguments-property-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/databaseprovider-connectionstringarguments-property-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: DatabaseProvider.ConnectionStringArguments Property (Microsoft.Web.Management.DatabaseManager)
+description: The DatabaseProvider.ConnectionStringArguments property gets a collection that contains the collection of database connection arguments.
 TOCTitle: ConnectionStringArguments Property
 ms:assetid: P:Microsoft.Web.Management.DatabaseManager.DatabaseProvider.ConnectionStringArguments
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.databaseprovider.connectionstringarguments(v=VS.90)

--- a/iis/extensions/database-manager-reference/dependenciesmissingexception-constructor-microsoft-web-management-databasemanager_1.md
+++ b/iis/extensions/database-manager-reference/dependenciesmissingexception-constructor-microsoft-web-management-databasemanager_1.md
@@ -1,6 +1,6 @@
 ---
 title: DependenciesMissingException Constructor  (Microsoft.Web.Management.DatabaseManager)
-description: This article contains information about syntax and permissions for the DependenciesMissingException constructor.
+description: This article contains information about the syntax of the DependenciesMissingException constructor.
 TOCTitle: DependenciesMissingException Constructor
 ms:assetid: M:Microsoft.Web.Management.DatabaseManager.DependenciesMissingException.#ctor
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.dependenciesmissingexception.dependenciesmissingexception(v=VS.90)

--- a/iis/extensions/database-manager-reference/dependenciesmissingexception-properties-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/dependenciesmissingexception-properties-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: DependenciesMissingException Properties (Microsoft.Web.Management.DatabaseManager)
+description: The DependenciesMissingException type exposes the properties described in this article.
 TOCTitle: DependenciesMissingException Properties
 ms:assetid: Properties.T:Microsoft.Web.Management.DatabaseManager.DependenciesMissingException
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.dependenciesmissingexception_properties(v=VS.90)

--- a/iis/extensions/database-manager-reference/foreignkey-constructor-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/foreignkey-constructor-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: ForeignKey Constructor  (Microsoft.Web.Management.DatabaseManager)
+description: The ForeignKey constructor creates a new instance of the ForeignKey class.
 TOCTitle: ForeignKey Constructor
 ms:assetid: M:Microsoft.Web.Management.DatabaseManager.ForeignKey.#ctor
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.foreignkey.foreignkey(v=VS.90)

--- a/iis/extensions/database-manager-reference/foreignkey-getchanges-method-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/foreignkey-getchanges-method-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: ForeignKey.GetChanges Method  (Microsoft.Web.Management.DatabaseManager)
+description: The ForeignKey.GetChanges method returns a value that indicates whether the foreign key has changes pending.
 TOCTitle: GetChanges Method
 ms:assetid: M:Microsoft.Web.Management.DatabaseManager.ForeignKey.GetChanges(Microsoft.Web.Management.DatabaseManager.ForeignKeyChanges)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.foreignkey.getchanges(v=VS.90)

--- a/iis/extensions/database-manager-reference/foreignkey-originalname-property-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/foreignkey-originalname-property-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: ForeignKey.OriginalName Property (Microsoft.Web.Management.DatabaseManager)
+description: The ForeignKey.OriginalName property gets or sets a value that specifies the original name of the foreign key.
 TOCTitle: OriginalName Property
 ms:assetid: P:Microsoft.Web.Management.DatabaseManager.ForeignKey.OriginalName
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.foreignkey.originalname(v=VS.90)

--- a/iis/extensions/database-manager-reference/foreignkeycolumn-fields-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/foreignkeycolumn-fields-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: ForeignKeyColumn Fields (Microsoft.Web.Management.DatabaseManager)
+description: The ForeignKeyColumn type exposes the fields described in this article.
 TOCTitle: ForeignKeyColumn Fields
 ms:assetid: Fields.T:Microsoft.Web.Management.DatabaseManager.ForeignKeyColumn
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.foreignkeycolumn_fields(v=VS.90)

--- a/iis/extensions/database-manager-reference/idbrestoremanager-interface-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/idbrestoremanager-interface-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: IDbRestoreManager Interface (Microsoft.Web.Management.DatabaseManager)
+description: The IDbRestoreManager interface represents a database restore manager interface.
 TOCTitle: IDbRestoreManager Interface
 ms:assetid: T:Microsoft.Web.Management.DatabaseManager.IDbRestoreManager
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.idbrestoremanager(v=VS.90)

--- a/iis/extensions/database-manager-reference/idbstoredproceduremanager-getstoredprocedurecreatestatement-method-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/idbstoredproceduremanager-getstoredprocedurecreatestatement-method-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: IDbStoredProcedureManager.GetStoredProcedureCreateStatement Method  (Microsoft.Web.Management.DatabaseManager)
+description: The IDbStoredProcedureManager.GetStoredProcedureCreateStatement method returns the CREATE PROCEDURE template for creating a new stored procedure.
 TOCTitle: GetStoredProcedureCreateStatement Method
 ms:assetid: M:Microsoft.Web.Management.DatabaseManager.IDbStoredProcedureManager.GetStoredProcedureCreateStatement(System.String)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.idbstoredproceduremanager.getstoredprocedurecreatestatement(v=VS.90)

--- a/iis/extensions/database-manager-reference/idbtablemanager-droptable-method-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/idbtablemanager-droptable-method-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: IDbTableManager.DropTable Method  (Microsoft.Web.Management.DatabaseManager)
+description: The IDbTableManager.DropTable method removes a table from the database.
 TOCTitle: DropTable Method
 ms:assetid: M:Microsoft.Web.Management.DatabaseManager.IDbTableManager.DropTable(System.String,System.String,Microsoft.Web.Management.DatabaseManager.TableInfo)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.idbtablemanager.droptable(v=VS.90)

--- a/iis/extensions/database-manager-reference/indexcolumn-descending-property-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/indexcolumn-descending-property-microsoft-web-management-databasemanager.md
@@ -2,7 +2,6 @@
 title: IndexColumn.Descending Property (Microsoft.Web.Management.DatabaseManager)
 description: Describes the IndexColumn.Descending property and provides the property's syntax, property values, examples, and permissions.
 TOCTitle: Descending Property
-description: Gets or sets a value that indicates whether the index column is a descending index.
 ms:assetid: P:Microsoft.Web.Management.DatabaseManager.IndexColumn.Descending
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.indexcolumn.descending(v=VS.90)
 ms:contentKeyID: 20476633

--- a/iis/extensions/database-manager-reference/indexcolumn-descendingindex-field-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/indexcolumn-descendingindex-field-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: IndexColumn.DescendingIndex Field (Microsoft.Web.Management.DatabaseManager)
+description: The IndexColumn.DescendingIndex field returns the index number for the index column's descending index.
 TOCTitle: DescendingIndex Field
 ms:assetid: F:Microsoft.Web.Management.DatabaseManager.IndexColumn.DescendingIndex
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.indexcolumn.descendingindex(v=VS.90)

--- a/iis/extensions/database-manager-reference/indexcolumn-nameindex-field-microsoft-web-management-databasemanager.md
+++ b/iis/extensions/database-manager-reference/indexcolumn-nameindex-field-microsoft-web-management-databasemanager.md
@@ -1,5 +1,6 @@
 ---
 title: IndexColumn.NameIndex Field (Microsoft.Web.Management.DatabaseManager)
+description: The IndexColumn.NameIndex field returns the index number for the column's name index.
 TOCTitle: NameIndex Field
 ms:assetid: F:Microsoft.Web.Management.DatabaseManager.IndexColumn.NameIndex
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.management.databasemanager.indexcolumn.nameindex(v=VS.90)


### PR DESCRIPTION
Changes to 27 topics: 

- preserve-view-not-set
- docs-link-absolute
- image-alt-text-duplicated
- yaml-duplicate-key
- description-missing
- duplicate-descriptions

There are build warnings, but we were told not to fix duplicate title or H1 issues.

Some of the new descriptions were shorter than our 100 char suggested length, but I left them unpadded because this is syntax reference. Let me know if you want us to add "Learn about . . ." or similar to bring the description length up.