### PR TITLE
Validation: Fix descriptions 

### DIFF
--- a/iis/extensions/smooth-streaming-client/adaptivesourcestatusupdatedeventargs-result-property.md
+++ b/iis/extensions/smooth-streaming-client/adaptivesourcestatusupdatedeventargs-result-property.md
@@ -1,5 +1,6 @@
 ---
 title: AdaptiveSourceStatusUpdatedEventArgs.Result Property
+description: Learn about the AdaptiveSourceStatusUpdatedEventArgs.Result property for Windows Store apps.
 TOCTitle: Result Property
 ms:assetid: ec8a65b6-cae4-48c5-8795-bf60752a173e
 ms:mtpsurl: https://msdn.microsoft.com/library/JJ822867(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/cacherequest-canonicaluri-property-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/cacherequest-canonicaluri-property-microsoft-web-media-smoothstreaming_1.md
@@ -1,5 +1,6 @@
 ---
 title: CacheRequest.CanonicalUri Property (Microsoft.Web.Media.SmoothStreaming)
+description: Learn about the CacheRequest.CanonicalUri property for Microsoft Smooth Streaming applications.
 TOCTitle: CanonicalUri Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.CacheRequest.CanonicalUri
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacherequest.canonicaluri(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/cacherequest2-webrequest-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacherequest2-webrequest-property-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: CacheRequest2.WebRequest Property (Microsoft.Web.Media.SmoothStreaming)
-descrption: Learn how the CacheRequest2.WebRequest property gets or sets a web request that the media element downloader uses for downloading.
+descrption: The CacheRequest2.WebRequest property gets or sets a web request that the media element downloader uses for downloading.
 TOCTitle: WebRequest Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.CacheRequest2.WebRequest
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacherequest2.webrequest(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-class-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-class-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: CacheResponse Class (Microsoft.Web.Media.SmoothStreaming)
+description: The CacheResponse Class is the object describing the response from the cache.
 TOCTitle: CacheResponse Class
 ms:assetid: T:Microsoft.Web.Media.SmoothStreaming.CacheResponse
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-class-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-class-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: CacheResponse Class (Microsoft.Web.Media.SmoothStreaming)
-description: The CacheResponse Class is the object describing the response from the cache.
+description: The CacheResponse class is the object describing the response from the cache.
 TOCTitle: CacheResponse Class
 ms:assetid: T:Microsoft.Web.Media.SmoothStreaming.CacheResponse
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-boolean-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-boolean-microsoft-web-media-smoothstreaming.md
@@ -1,7 +1,7 @@
 ---
 title: CacheResponse Constructor (Stream, Boolean) (Microsoft.Web.Media.SmoothStreaming)
+description: The CacheResponse Constructor (Stream, Boolean) initializes a new instance of the CacheResponse class from a Stream object.
 TOCTitle: CacheResponse Constructor (Stream, Boolean)
-description: Initializes a new instance of the CacheResponse object.
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.CacheResponse.#ctor(System.IO.Stream,System.Boolean)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.cacheresponse(v=VS.95)
 ms:contentKeyID: 46307640

--- a/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-boolean-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-boolean-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: CacheResponse Constructor (Stream, Boolean) (Microsoft.Web.Media.SmoothStreaming)
-description: The CacheResponse Constructor (Stream, Boolean) initializes a new instance of the CacheResponse class from a Stream object.
+description: The CacheResponse constructor (Stream, Boolean) initializes a new instance of the CacheResponse class from a Stream object.
 TOCTitle: CacheResponse Constructor (Stream, Boolean)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.CacheResponse.#ctor(System.IO.Stream,System.Boolean)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.cacheresponse(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: CacheResponse Constructor (Stream) (Microsoft.Web.Media.SmoothStreaming)
-description: The CacheResponse Constructor (Stream) initializes a new instance of the CacheResponse class from a Stream object.
+description: The CacheResponse constructor (Stream) initializes a new instance of the CacheResponse class from a Stream object.
 TOCTitle: CacheResponse Constructor (Stream)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.CacheResponse.#ctor(System.IO.Stream)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.cacheresponse(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: CacheResponse Constructor (Stream) (Microsoft.Web.Media.SmoothStreaming)
+description: The CacheResponse Constructor (Stream) initializes a new instance of the CacheResponse class from a Stream object.
 TOCTitle: CacheResponse Constructor (Stream)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.CacheResponse.#ctor(System.IO.Stream)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.cacheresponse(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: CacheResponse Constructor (Stream) (Microsoft.Web.Media.SmoothStreaming)
-description: Learn how the CacheResponse Constructor (Stream) initializes a new instance of the CacheResponse class from a Stream object.
+description: Learn how the CacheResponse constructor (Stream) initializes a new instance of the CacheResponse class from a Stream object.
 TOCTitle: CacheResponse Constructor (Stream)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.CacheResponse.#ctor(System.IO.Stream)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.cacheresponse(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-constructor-stream-microsoft-web-media-smoothstreaming_1.md
@@ -1,7 +1,7 @@
 ---
 title: CacheResponse Constructor (Stream) (Microsoft.Web.Media.SmoothStreaming)
+description: Learn how the CacheResponse Constructor (Stream) initializes a new instance of the CacheResponse class from a Stream object.
 TOCTitle: CacheResponse Constructor (Stream)
-description: Initializes a new instance of the CacheResponse object.
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.CacheResponse.#ctor(System.IO.Stream)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.cacheresponse(v=VS.95)
 ms:contentKeyID: 46500551

--- a/iis/extensions/smooth-streaming-client/cacheresponse-statuscode-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/cacheresponse-statuscode-property-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: CacheResponse.StatusCode Property (Microsoft.Web.Media.SmoothStreaming)
+description: The StatusCode property is an HTTPStatusCode enumeration object.
 TOCTitle: StatusCode Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.CacheResponse.StatusCode
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.cacheresponse.statuscode(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/chunkresult-result-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/chunkresult-result-property-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: ChunkResult.Result Property (Microsoft.Web.Media.SmoothStreaming)
-description: Describes the ChunkResult.Result property and details its syntax, property value, and Silverlight information.
+description: Learn how the Result property gets or sets the result of call to BeginGetChunk or GetChunkUri.
 TOCTitle: Result Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.ChunkResult.Result
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.chunkresult.result(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/chunkresult-result-property-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/chunkresult-result-property-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: ChunkResult.Result Property (Microsoft.Web.Media.SmoothStreaming)
-description: Describes the ChunkResult.Result property and details its syntax, property value, and Silverlight information.
+description: Learn how the ChunkResult.Result property gets or sets the result of call to BeginGetChunk or GetChunkUri.
 TOCTitle: Result Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.ChunkResult.Result
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.chunkresult.result(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/circularlist-t-constructor-microsoft-web-media-diagnostics_1.md
+++ b/iis/extensions/smooth-streaming-client/circularlist-t-constructor-microsoft-web-media-diagnostics_1.md
@@ -1,6 +1,6 @@
 ---
 title: CircularList(T) Constructor  (Microsoft.Web.Media.Diagnostics)
-description: The CircularList<T> Constructor initializes a new instance of the CircularList<T> class. (Deprecated. Do not use)
+description: The CircularList<T> constructor initializes a new instance of the CircularList<T> class. (Deprecated. Do not use)
 TOCTitle: CircularList(T) Constructor
 ms:assetid: M:Microsoft.Web.Media.Diagnostics.CircularList`1.#ctor(System.Int32)
 ms:mtpsurl: https://msdn.microsoft.com/library/Ff728288(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/circularlist-t-constructor-microsoft-web-media-diagnostics_1.md
+++ b/iis/extensions/smooth-streaming-client/circularlist-t-constructor-microsoft-web-media-diagnostics_1.md
@@ -1,5 +1,6 @@
 ---
 title: CircularList(T) Constructor  (Microsoft.Web.Media.Diagnostics)
+description: The CircularList<T> Constructor initializes a new instance of the CircularList<T> class. (Deprecated. Do not use)
 TOCTitle: CircularList(T) Constructor
 ms:assetid: M:Microsoft.Web.Media.Diagnostics.CircularList`1.#ctor(System.Int32)
 ms:mtpsurl: https://msdn.microsoft.com/library/Ff728288(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/circularlist-t-sort-method-microsoft-web-media-diagnostics_1.md
+++ b/iis/extensions/smooth-streaming-client/circularlist-t-sort-method-microsoft-web-media-diagnostics_1.md
@@ -1,5 +1,6 @@
 ---
 title: CircularList(T).Sort Method  (Microsoft.Web.Media.Diagnostics)
+description: The CircularList<T>.Sort method sorts the elements in a range of elements in CircularList<T> using the specified comparer.
 TOCTitle: Sort Method
 ms:assetid: Overload:Microsoft.Web.Media.Diagnostics.CircularList`1.Sort
 ms:mtpsurl: https://msdn.microsoft.com/library/Ff728197(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/clipeventargs-properties-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/clipeventargs-properties-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: ClipEventArgs Properties (Microsoft.Web.Media.SmoothStreaming)
+description: Learn about the ClipEventArgs properties for Microsoft Smooth Streaming applications.
 TOCTitle: ClipEventArgs Properties
 descriptions: "The Context property is listed as a member that is exposed by the ClipEventArgs type. It shows the property type, name, and description."
 ms:assetid: Properties.T:Microsoft.Web.Media.SmoothStreaming.ClipEventArgs

--- a/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-duration-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-duration-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: ClipInformation Constructor (Boolean, Uri, Duration) (Microsoft.Web.Media.SmoothStreaming)
-description: The ClipInformation Constructor (Boolean, Uri, Duration) initializes a new instance of the ClipInformation class. 
+description: The ClipInformation constructor (Boolean, Uri, Duration) initializes a new instance of the ClipInformation class. 
 TOCTitle: ClipInformation Constructor (Boolean, Uri, Duration)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.ClipInformation.#ctor(System.Boolean,System.Uri,System.Windows.Duration)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipinformation.clipinformation(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-duration-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-duration-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: ClipInformation Constructor (Boolean, Uri, Duration) (Microsoft.Web.Media.SmoothStreaming)
-description: This article contains syntax and version information for the ClipInformation constructor. There are also links to reference materials.
+description: The ClipInformation Constructor (Boolean, Uri, Duration) initializes a new instance of the ClipInformation class. 
 TOCTitle: ClipInformation Constructor (Boolean, Uri, Duration)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.ClipInformation.#ctor(System.Boolean,System.Uri,System.Windows.Duration)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipinformation.clipinformation(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-uri-duration-ismoothstreamingcache-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-uri-duration-ismoothstreamingcache-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: ClipInformation Constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache) (Microsoft.Web.Media.SmoothStreaming)
-description: This article contains syntax and version information for the ClipInformation constructor. There are also links to reference materials.
+description: The ClipInformation Constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache) initializes a new instance of the ClipInformation class.
 TOCTitle: ClipInformation Constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.ClipInformation.#ctor(System.Boolean,System.Uri,System.Uri,System.Windows.Duration,Microsoft.Web.Media.SmoothStreaming.ISmoothStreamingCache)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipinformation.clipinformation(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-uri-duration-ismoothstreamingcache-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/clipinformation-constructor-boolean-uri-uri-duration-ismoothstreamingcache-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: ClipInformation Constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache) (Microsoft.Web.Media.SmoothStreaming)
-description: The ClipInformation Constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache) initializes a new instance of the ClipInformation class.
+description: The ClipInformation constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache) initializes a new instance of the ClipInformation class.
 TOCTitle: ClipInformation Constructor (Boolean, Uri, Uri, Duration, ISmoothStreamingCache)
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.ClipInformation.#ctor(System.Boolean,System.Uri,System.Uri,System.Windows.Duration,Microsoft.Web.Media.SmoothStreaming.ISmoothStreamingCache)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipinformation.clipinformation(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/clipinformation-issmoothstreamingsource-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/clipinformation-issmoothstreamingsource-property-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: ClipInformation.IsSmoothStreamingSource Property (Microsoft.Web.Media.SmoothStreaming)
+description: The IsSmoothStreamingSource Property gets or sets a Boolean value that indicates whether the media clip is in Smooth Streaming format.
 TOCTitle: IsSmoothStreamingSource Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.ClipInformation.IsSmoothStreamingSource
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipinformation.issmoothstreamingsource(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/clipinformation-issmoothstreamingsource-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/clipinformation-issmoothstreamingsource-property-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: ClipInformation.IsSmoothStreamingSource Property (Microsoft.Web.Media.SmoothStreaming)
-description: The IsSmoothStreamingSource Property gets or sets a Boolean value that indicates whether the media clip is in Smooth Streaming format.
+description: The IsSmoothStreamingSource property gets or sets a Boolean value that indicates whether the media clip is in Smooth Streaming format.
 TOCTitle: IsSmoothStreamingSource Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.ClipInformation.IsSmoothStreamingSource
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipinformation.issmoothstreamingsource(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/clipplaybackeventargs-class-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/clipplaybackeventargs-class-microsoft-web-media-smoothstreaming_1.md
@@ -1,5 +1,6 @@
 ---
 title: ClipPlaybackEventArgs Class (Microsoft.Web.Media.SmoothStreaming)
+description: The ClipPlaybackEventArgs class contains event data for a media clip event.
 TOCTitle: ClipPlaybackEventArgs Class
 ms:assetid: T:Microsoft.Web.Media.SmoothStreaming.ClipPlaybackEventArgs
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.clipplaybackeventargs(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/iadaptivesource-adaptivesourcestatusupdatedevent-event.md
+++ b/iis/extensions/smooth-streaming-client/iadaptivesource-adaptivesourcestatusupdatedevent-event.md
@@ -1,7 +1,7 @@
 ---
 title: IAdaptiveSource.AdaptiveSourceStatusUpdatedEvent Event
 TOCTitle: AdaptiveSourceStatusUpdatedEvent Event
-description: Adds the status updated event handler.
+description: The IAdaptiveSource.AdaptiveSourceStatusUpdatedEvent event adds the status updated event handler.
 ms:assetid: d35f9a59-663d-491b-b387-65a287d766f0
 ms:mtpsurl: https://msdn.microsoft.com/library/JJ822839(v=VS.90)
 ms:contentKeyID: 50079593

--- a/iis/extensions/smooth-streaming-client/iadaptivesourcemanager-adaptivesourcestatusupdatedevent-event.md
+++ b/iis/extensions/smooth-streaming-client/iadaptivesourcemanager-adaptivesourcestatusupdatedevent-event.md
@@ -1,7 +1,7 @@
 ---
 title: IAdaptiveSourceManager.AdaptiveSourceStatusUpdatedEvent Event
 TOCTitle: AdaptiveSourceStatusUpdatedEvent Event
-description: Adds the status updated event handler.
+description: Learn how the IAdaptiveSourceManager.AdaptiveSourceStatusUpdatedEvent event adds the status updated event handler.
 ms:assetid: 9368d96a-29ec-48e1-9eaa-4fb7b0fd0b67
 ms:mtpsurl: https://msdn.microsoft.com/library/JJ822785(v=VS.90)
 ms:contentKeyID: 50079539

--- a/iis/extensions/smooth-streaming-client/smoothstreamingexception-methods-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingexception-methods-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingException Methods (Microsoft.Web.Media.SmoothStreaming)
-description: Describes the SmoothStreamingException methods and provides a table that outlines the name and description for various method types.
+description: Outlines the SmoothStreamingException methods and provides a table listing the name and description for various method types.
 TOCTitle: SmoothStreamingException Methods
 ms:assetid: Methods.T:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingException
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingexception_methods(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingexception-methods-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingexception-methods-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingException Methods (Microsoft.Web.Media.SmoothStreaming)
-description: Describes the SmoothStreamingException methods and provides a table that outlines the name and description for various method types.
+description: Describes the SmoothStreamingException methods and provides a table that listing the name and description for various method types.
 TOCTitle: SmoothStreamingException Methods
 ms:assetid: Methods.T:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingException
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingexception_methods(v=VS.95)


### PR DESCRIPTION
This PR addresses the following issues:
duplicate-descriptions
description-missing

There are build warnings, but we were instructed not to fix duplicate title or H1 issues.