### PR TITLE
Validation: Fix descriptions 

### DIFF
--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-configpathproperty-field-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-configpathproperty-field-microsoft-web-media-smoothstreaming_1.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.ConfigPathProperty Field (Microsoft.Web.Media.SmoothStreaming)
+description: The SmoothStreamingMediaElement.ConfigPathProperty field represents a dependency property that specifies the ConfigPath property.
 TOCTitle: ConfigPathProperty Field
 ms:assetid: F:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.ConfigPathProperty
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.configpathproperty(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-currentsegmentindex-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-currentsegmentindex-property-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.CurrentSegmentIndex Property (Microsoft.Web.Media.SmoothStreaming)
-description: The CurrentSegmentIndex Property gets the index of the current playing segment.
+description: The CurrentSegmentIndex property gets the index of the current playing segment.
 TOCTitle: CurrentSegmentIndex Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.CurrentSegmentIndex
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.currentsegmentindex(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-currentsegmentindex-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-currentsegmentindex-property-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.CurrentSegmentIndex Property (Microsoft.Web.Media.SmoothStreaming)
+description: The CurrentSegmentIndex Property gets the index of the current playing segment.
 TOCTitle: CurrentSegmentIndex Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.CurrentSegmentIndex
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.currentsegmentindex(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-currentsegmentindexproperty-field-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-currentsegmentindexproperty-field-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.CurrentSegmentIndexProperty Field (Microsoft.Web.Media.SmoothStreaming)
-description: Describes the CurrentSegmentIndexProperty field and provides the field's syntax, version information, and permissions.
+description: The CurrentSegmentIndexProperty field represents a dependency property.
 TOCTitle: CurrentSegmentIndexProperty Field
 description: Represents a dependency property.
 ms:assetid: F:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.CurrentSegmentIndexProperty

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-downloadprogressproperty-field-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-downloadprogressproperty-field-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.DownloadProgressProperty Field (Microsoft.Web.Media.SmoothStreaming)
-descriptions: This article contains syntax, permissions, and version information for the SmoothStreamingMediaElement.DownloadProgressProperty field.
+descriptions: The DownloadProgressProperty field represents a dependency property that specifies the DownloadProgress property.
 TOCTitle: DownloadProgressProperty Field
 ms:assetid: F:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.DownloadProgressProperty
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.downloadprogressproperty(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-latencycorrectionthresholdproperty-field-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-latencycorrectionthresholdproperty-field-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.LatencyCorrectionThresholdProperty Field (Microsoft.Web.Media.SmoothStreaming)
+description: The LatencyCorrectionThresholdProperty field represents a dependency property that specifies the LatencyCorrectionThreshold property.
 TOCTitle: LatencyCorrectionThresholdProperty Field
 ms:assetid: F:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.LatencyCorrectionThresholdProperty
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.latencycorrectionthresholdproperty(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-livebackoff-property-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-livebackoff-property-microsoft-web-media-smoothstreaming_1.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.LiveBackOff Property (Microsoft.Web.Media.SmoothStreaming)
+description: The SmoothStreamingMediaElement.LiveBackOff property gets or sets the duration of content closest to live that cannot yet be downloaded.
 TOCTitle: LiveBackOff Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.LiveBackOff
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.livebackoff(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-livebackoffproperty-field-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-livebackoffproperty-field-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.LiveBackOffProperty Field (Microsoft.Web.Media.SmoothStreaming)
+description: The LiveBackOffProperty field represents a dependency property that specifies the LiveBackOff property.
 TOCTitle: LiveBackOffProperty Field
 ms:assetid: F:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.LiveBackOffProperty
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.livebackoffproperty(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-liveposition-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-liveposition-property-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.LivePosition Property (Microsoft.Web.Media.SmoothStreaming)
+description: The LivePosition property gets the position that is nearest to the live stream that a client can seek to.
 TOCTitle: LivePosition Property
 description: Gets the position that is nearest to the live stream that a client can seek to.
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.LivePosition

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-liveposition-property-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-liveposition-property-microsoft-web-media-smoothstreaming_1.md
@@ -1,7 +1,7 @@
 ---
 title: SmoothStreamingMediaElement.LivePosition Property (Microsoft.Web.Media.SmoothStreaming)
 TOCTitle: LivePosition Property
-description: Gets the position that is nearest to the live stream that a client can seek to.
+description: The SmoothStreamingMediaElement.LivePosition property gets the position that is nearest to the live stream that a client can seek to.
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.LivePosition
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.liveposition(v=VS.95)
 ms:contentKeyID: 46307830

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-naturalvideoheightproperty-field-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-naturalvideoheightproperty-field-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.NaturalVideoHeightProperty Field (Microsoft.Web.Media.SmoothStreaming)
-description: The NaturalVideoHeightProperty Field represents a dependency property that specifies the NaturalHeight()()()() property. This article details syntax, version information, and permissions.
+description: The NaturalVideoHeightProperty field represents a dependency property that specifies the NaturalHeight()()()() property. 
 TOCTitle: NaturalVideoHeightProperty Field
 description: "The NaturalVideoHeightProperty field represents a dependency property that specifies the NaturalHeight property."
 ms:assetid: F:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.NaturalVideoHeightProperty

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.RenderedFramesPerSecond Property (Microsoft.Web.Media.SmoothStreaming)
-TOCTitle: RenderedFramesPerSecond Property
+TOCTitle: The RenderedFramesPerSecond property gets the rate of rendered frames.
 description: Gets the rate of rendered frames.
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.RenderedFramesPerSecond
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.renderedframespersecond(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,7 @@
 ---
 title: SmoothStreamingMediaElement.RenderedFramesPerSecond Property (Microsoft.Web.Media.SmoothStreaming)
-TOCTitle: The RenderedFramesPerSecond property gets the rate of rendered frames.
+description: The RenderedFramesPerSecond property gets the rate of rendered frames.
+TOCTitle: RenderedFramesPerSecond Property
 description: Gets the rate of rendered frames.
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.RenderedFramesPerSecond
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.renderedframespersecond(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.RenderedFramesPerSecond Property (Microsoft.Web.Media.SmoothStreaming)
-TOCTitle: RenderedFramesPerSecond Property
+TOCTitle: The SmoothStreamingMediaElement.RenderedFramesPerSecond property gets the rate of rendered frames.
 description: Gets the rate of rendered frames.
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.RenderedFramesPerSecond
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.renderedframespersecond(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-renderedframespersecond-property-microsoft-web-media-smoothstreaming_1.md
@@ -1,7 +1,7 @@
 ---
 title: SmoothStreamingMediaElement.RenderedFramesPerSecond Property (Microsoft.Web.Media.SmoothStreaming)
-TOCTitle: The SmoothStreamingMediaElement.RenderedFramesPerSecond property gets the rate of rendered frames.
-description: Gets the rate of rendered frames.
+TOCTitle: RenderedFramesPerSecond Property
+description: The SmoothStreamingMediaElement.RenderedFramesPerSecond property gets the rate of rendered frames.
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.RenderedFramesPerSecond
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.renderedframespersecond(v=VS.95)
 ms:contentKeyID: 46307850

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-smoothstreamingcache-property-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-smoothstreamingcache-property-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.SmoothStreamingCache Property (Microsoft.Web.Media.SmoothStreaming)
+description: The SmoothStreamingCache property gets or sets the Smooth Streaming cache to use during main content playback.
 TOCTitle: SmoothStreamingCache Property
 ms:assetid: P:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.SmoothStreamingCache
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.smoothstreamingcache(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-videohighestplayabletrackchanged-event-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/smoothstreamingmediaelement-videohighestplayabletrackchanged-event-microsoft-web-media-smoothstreaming.md
@@ -1,5 +1,6 @@
 ---
 title: SmoothStreamingMediaElement.VideoHighestPlayableTrackChanged Event (Microsoft.Web.Media.SmoothStreaming)
+description: The VideoHighestPlayableTrackChanged event occurs when the playback rate changes to the highest available rate.
 TOCTitle: VideoHighestPlayableTrackChanged Event
 ms:assetid: E:Microsoft.Web.Media.SmoothStreaming.SmoothStreamingMediaElement.VideoHighestPlayableTrackChanged
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.smoothstreamingmediaelement.videohighestplayabletrackchanged(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/streaminfo-selecttracks-method-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/streaminfo-selecttracks-method-microsoft-web-media-smoothstreaming_1.md
@@ -1,6 +1,7 @@
 ---
 title: StreamInfo.SelectTracks Method  (Microsoft.Web.Media.SmoothStreaming)
 TOCTitle: SelectTracks Method
+description: Learn how the StreamInfo.SelectTracks method selects TrackInfo objects for a stream. 
 ms:assetid: M:Microsoft.Web.Media.SmoothStreaming.StreamInfo.SelectTracks(System.Collections.Generic.IList{Microsoft.Web.Media.SmoothStreaming.TrackInfo},System.Boolean)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.streaminfo.selecttracks(v=VS.95)
 ms:contentKeyID: 46307697

--- a/iis/extensions/smooth-streaming-client/streamupdatedeventargs-class-microsoft-web-media-smoothstreaming.md
+++ b/iis/extensions/smooth-streaming-client/streamupdatedeventargs-class-microsoft-web-media-smoothstreaming.md
@@ -1,6 +1,6 @@
 ---
 title: StreamUpdatedEventArgs Class (Microsoft.Web.Media.SmoothStreaming)
-description: Arguments for the StreamSelected, ChunkAdded and TracksSelected events.
+description: Learn about the StreamUpdatedEventArgs class for Microsoft Smooth Streaming.
 TOCTitle: StreamUpdatedEventArgs Class
 description: "The StreamUpdatedEventArgs class arguments for the StreamSelected, ChunkAdded and TracksSelected events."
 ms:assetid: T:Microsoft.Web.Media.SmoothStreaming.StreamUpdatedEventArgs

--- a/iis/extensions/smooth-streaming-client/streamupdatedlisteventargs-constructor-microsoft-web-media-smoothstreaming_1.md
+++ b/iis/extensions/smooth-streaming-client/streamupdatedlisteventargs-constructor-microsoft-web-media-smoothstreaming_1.md
@@ -1,5 +1,6 @@
 ---
 title: StreamUpdatedListEventArgs Constructor  (Microsoft.Web.Media.SmoothStreaming)
+description: The StreamUpdatedListEventArgs constructor initializes a new instance of the StreamUpdatedListEventArgs class.
 TOCTitle: StreamUpdatedListEventArgs Constructor
 ms:assetid: Overload:Microsoft.Web.Media.SmoothStreaming.StreamUpdatedListEventArgs.#ctor
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.smoothstreaming.streamupdatedlisteventargs.streamupdatedlisteventargs(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/tracing-includetracearea-field-microsoft-web-media-diagnostics.md
+++ b/iis/extensions/smooth-streaming-client/tracing-includetracearea-field-microsoft-web-media-diagnostics.md
@@ -1,5 +1,6 @@
 ---
 title: Tracing.IncludeTraceArea Field (Microsoft.Web.Media.Diagnostics)
+description: The IncludeTraceArea field is a Boolean value that indicates whether to include the trace area in traces.
 TOCTitle: IncludeTraceArea Field
 ms:assetid: F:Microsoft.Web.Media.Diagnostics.Tracing.IncludeTraceArea
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.diagnostics.tracing.includetracearea(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/tracing-trace-method-string-string-tracearea-tracelevel-string-object[]-microsoft-web-media-diagnostics.md
+++ b/iis/extensions/smooth-streaming-client/tracing-trace-method-string-string-tracearea-tracelevel-string-object[]-microsoft-web-media-diagnostics.md
@@ -1,5 +1,6 @@
 ---
 title: Tracing.Trace Method (String, String, TraceArea, TraceLevel, String, Object[]) (Microsoft.Web.Media.Diagnostics)
+description: The Trace method (String, String, TraceArea, TraceLevel, String, Object[]) traces a diagnostic message that is specified by the parameters.
 TOCTitle: Trace Method (String, String, TraceArea, TraceLevel, String, Object[])
 ms:assetid: M:Microsoft.Web.Media.Diagnostics.Tracing.Trace(System.String,System.String,Microsoft.Web.Media.Diagnostics.TraceArea,Microsoft.Web.Media.Diagnostics.TraceLevel,System.String,System.Object[])
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.diagnostics.tracing.trace(v=VS.90)

--- a/iis/extensions/smooth-streaming-client/tracing-tracefunctionentry-method-tracearea-microsoft-web-media-diagnostics_1.md
+++ b/iis/extensions/smooth-streaming-client/tracing-tracefunctionentry-method-tracearea-microsoft-web-media-diagnostics_1.md
@@ -1,5 +1,6 @@
 ---
 title: Tracing.TraceFunctionEntry Method (TraceArea) (Microsoft.Web.Media.Diagnostics)
+description: The Tracing.TraceFunctionEntry method (TraceArea) records the entry into a function as specified by the parameters.
 TOCTitle: TraceFunctionEntry Method (TraceArea)
 ms:assetid: M:Microsoft.Web.Media.Diagnostics.Tracing.TraceFunctionEntry(Microsoft.Web.Media.Diagnostics.TraceArea)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.diagnostics.tracing.tracefunctionentry(v=VS.95)

--- a/iis/extensions/smooth-streaming-client/tracing-tracefunctionexit-method-tracearea-microsoft-web-media-diagnostics.md
+++ b/iis/extensions/smooth-streaming-client/tracing-tracefunctionexit-method-tracearea-microsoft-web-media-diagnostics.md
@@ -1,5 +1,6 @@
 ---
 title: Tracing.TraceFunctionExit Method (TraceArea) (Microsoft.Web.Media.Diagnostics)
+description: The TraceFunctionExit method (TraceArea) records the exit from a function as specified by the parameter.
 TOCTitle: TraceFunctionExit Method (TraceArea)
 description: "The Tracing.TraceFunctionExit method records the exit from a function as specified by the parameter."
 ms:assetid: M:Microsoft.Web.Media.Diagnostics.Tracing.TraceFunctionExit(Microsoft.Web.Media.Diagnostics.TraceArea)

--- a/iis/extensions/smooth-streaming-client/tracing-tracefunctionexit-method-tracearea-microsoft-web-media-diagnostics_1.md
+++ b/iis/extensions/smooth-streaming-client/tracing-tracefunctionexit-method-tracearea-microsoft-web-media-diagnostics_1.md
@@ -1,7 +1,7 @@
 ---
 title: Tracing.TraceFunctionExit Method (TraceArea) (Microsoft.Web.Media.Diagnostics)
 TOCTitle: TraceFunctionExit Method (TraceArea)
-description: "The Tracing.TraceFunctionExit method records the exit from a function as specified by the parameter."
+description: The Tracing.TraceFunctionExit method (TraceArea) records the exit from a function as specified by the parameter.
 ms:assetid: M:Microsoft.Web.Media.Diagnostics.Tracing.TraceFunctionExit(Microsoft.Web.Media.Diagnostics.TraceArea)
 ms:mtpsurl: https://msdn.microsoft.com/library/microsoft.web.media.diagnostics.tracing.tracefunctionexit(v=VS.95)
 ms:contentKeyID: 46307633


### PR DESCRIPTION
This PR addresses the following issues:
duplicate-descriptions
description-missing

There are build warnings, but we were instructed not to fix duplicate title or H1 issues.
