### PR TITLE
fix hidden path separators

### DIFF
--- a/iis/configuration/system.applicationHost/sites/site/ftpServer/userIsolation/index.md
+++ b/iis/configuration/system.applicationHost/sites/site/ftpServer/userIsolation/index.md
@@ -30,9 +30,9 @@ When using either the **IsolateRootDirectoryOnly** or **IsolateAllDirectories** 
 > | User Account Types | Home Directory Syntax |
 > | --- | --- |
 > | Anonymous users | %*FtpRoot*%\LocalUser\Public |
-> | Local Windows user accounts (Requires Basic authentication) | %*FtpRoot*%\LocalUser\%*UserName*% |
-> | Windows domain accounts (Requires Basic authentication) | %*FtpRoot*%\%UserDomain%\%*UserName*% |
-> | IIS Manager or ASP.NET custom authentication user accounts | %*FtpRoot*%\LocalUser\%*UserName*% |
+> | Local Windows user accounts (Requires Basic authentication) | %*FtpRoot*%\LocalUser\\%*UserName*% |
+> | Windows domain accounts (Requires Basic authentication) | %*FtpRoot*%\\%UserDomain%\\%*UserName*% |
+> | IIS Manager or ASP.NET custom authentication user accounts | %*FtpRoot*%\LocalUser\\%*UserName*% |
 
 <a id="002"></a>
 ## Compatibility

--- a/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/userIsolation/index.md
+++ b/iis/configuration/system.applicationHost/sites/siteDefaults/ftpServer/userIsolation/index.md
@@ -30,9 +30,9 @@ When using either the **IsolateRootDirectoryOnly** or **IsolateAllDirectories** 
 > | User Account Types | Home Directory Syntax |
 > | --- | --- |
 > | Anonymous users | %*FtpRoot*%\LocalUser\Public |
-> | Local Windows user accounts (Requires Basic authentication) | %*FtpRoot*%\LocalUser\%*UserName*% |
-> | Windows domain accounts (Requires Basic authentication) | %*FtpRoot*%\%UserDomain%\%*UserName*% |
-> | IIS Manager or ASP.NET custom authentication user accounts | %*FtpRoot*%\LocalUser\%*UserName*% |
+> | Local Windows user accounts (Requires Basic authentication) | %*FtpRoot*%\LocalUser\\%*UserName*% |
+> | Windows domain accounts (Requires Basic authentication) | %*FtpRoot*%\\%UserDomain%\\%*UserName*% |
+> | IIS Manager or ASP.NET custom authentication user accounts | %*FtpRoot*%\LocalUser\\%*UserName*% |
 
 <a id="002"></a>
 ## Compatibility

--- a/iis/publish/using-the-ftp-service/configuring-ftp-user-isolation-in-iis-7.md
+++ b/iis/publish/using-the-ftp-service/configuring-ftp-user-isolation-in-iis-7.md
@@ -186,9 +186,9 @@ To create home directories for each user, you first need to create a physical di
 | User Account Types | Physical Home Directory Syntax |
 | --- | --- |
 | Anonymous users | %FtpRoot%\LocalUser\Public |
-| Local Windows user accounts (requires basic authentication) | %FtpRoot%\LocalUser\%UserName% |
-| Windows domain accounts (requires basic authentication) | %FtpRoot%\%UserDomain%\%UserName% |
-| IIS Manager or ASP.NET custom authentication user accounts | %FtpRoot%\LocalUser\%UserName% |
+| Local Windows user accounts (requires basic authentication) | %FtpRoot%\LocalUser\\%UserName% |
+| Windows domain accounts (requires basic authentication) | %FtpRoot%\\%UserDomain%\\%UserName% |
+| IIS Manager or ASP.NET custom authentication user accounts | %FtpRoot%\LocalUser\\%UserName% |
 
 > [!NOTE]
 > In the above table, %FtpRoot% is the root directory for your FTP site; for example, `C:\Inetpub\Ftproot`.

--- a/iis/web-hosting/configuring-servers-in-the-windows-web-platform/guide-to-deploy-ftp-and-publish-with-vwd.md
+++ b/iis/web-hosting/configuring-servers-in-the-windows-web-platform/guide-to-deploy-ftp-and-publish-with-vwd.md
@@ -148,9 +148,9 @@ To create home directories for each user, you first need to create a virtual or 
 | **User Account Type** | **Physical Home Directory Syntax** |
 | --- | --- |
 | Anonymous users | %*FtpRoot*%\LocalUser\Public |
-| Local Windows user accounts (requires Basic authentication) | %*FtpRoot*%\LocalUser\%*UserName*% |
-| Windows domain accounts (requires Basic authentication) | %*FtpRoot*%\%UserDomain%\%*UserName*% |
-| IIS Manager or ASP.NET custom authentication user accounts | %*FtpRoot*%\LocalUser\%*UserName*% |
+| Local Windows user accounts (requires Basic authentication) | %*FtpRoot*%\LocalUser\\%*UserName*% |
+| Windows domain accounts (requires Basic authentication) | %*FtpRoot*%\\%UserDomain%\\%*UserName*% |
+| IIS Manager or ASP.NET custom authentication user accounts | %*FtpRoot*%\LocalUser\\%*UserName*% |
 
 > [!NOTE]
 > In the above table, %*FtpRoot*% is the root directory for your FTP site; for example, `C:\Inetpub\Ftproot`.


### PR DESCRIPTION
Show hidden path separators.
It's fine for plain text, but it was hidden in Markdown.