### PR TITLE
Fix httpLogging example desc. for dontLog=true

### DIFF
--- a/iis/configuration/system.webServer/httpLogging.md
+++ b/iis/configuration/system.webServer/httpLogging.md
@@ -90,7 +90,7 @@ The following configuration example, when included in a Web.config file for a si
 <a id="006"></a>
 ## Sample Code
 
-The following examples enable HTTP logging for a Web site named Contoso, and specify that IIS should log all requests.
+The following examples enable HTTP logging for a Web site named Contoso, and specify that IIS shouldn't log any requests.
 
 ### AppCmd.exe
 


### PR DESCRIPTION
All the below examples have dontLog set to true which means IIS won't log requests.

https://learn.microsoft.com/en-us/iis/configuration/system.webserver/httplogging#sample-code