### PR TITLE
[BrokenLinksH2]

### DIFF
--- a/iis/application-frameworks/running-php-applications-on-iis/mix08-partying-with-php-on-microsoft-internet-information-services-7-and-above.md
+++ b/iis/application-frameworks/running-php-applications-on-iis/mix08-partying-with-php-on-microsoft-internet-information-services-7-and-above.md
@@ -11,4 +11,4 @@ msc.type: video
 
 by [Drew Robbins](https://github.com/drewby)
 
-This video is from the MIX08 conference. http://visitmix.com Discover the advantages of running PHP applications on Microsoft Internet Information Services. Learn how to take advantage of the integrated pipeline and .NET functionality, and use the new remote management tools.
+This video is from the MIX08 conference. Discover the advantages of running PHP applications on Microsoft Internet Information Services. Learn how to take advantage of the integrated pipeline and .NET functionality, and use the new remote management tools.


### PR DESCRIPTION
**Global effort to fix broken links**

@Rick-Anderson
@mcleblanc

The C+E Skilling team is fixing broken links on learn.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!