### PR TITLE
Update introduction-to-web-deploy.md

### DIFF
--- a/iis/publish/using-web-deploy/introduction-to-web-deploy.md
+++ b/iis/publish/using-web-deploy/introduction-to-web-deploy.md
@@ -66,4 +66,4 @@ When a source initiates an action through Web Deploy, the Web Deploy Framework e
 
 ## To Learn More
 
-Please visit our [walkthrough tutorials on iis.net](../deploying-application-packages/index.md) and our [technet documentation](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd568996(v=ws.10)).
+Please visit our [walkthrough tutorials on iis.net](../deploying-application-packages/index.md) and our [technet documentation](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd568996(v=ws.10)).

--- a/iis/publish/using-web-deploy/introduction-to-web-deploy.md
+++ b/iis/publish/using-web-deploy/introduction-to-web-deploy.md
@@ -66,4 +66,4 @@ When a source initiates an action through Web Deploy, the Web Deploy Framework e
 
 ## To Learn More
 
-Please visit our [walkthrough tutorials on iis.net](../deploying-application-packages/index.md) and our [technet documentation](https://technet.microsoft.com/library/dd568996(v=ws.10).aspx).
+Please visit our [walkthrough tutorials on iis.net](../deploying-application-packages/index.md) and our [technet documentation](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd568996(v=ws.10)).


### PR DESCRIPTION
TechNet URL redirection not working correctly on `technet documentation` link at the bottom of the page - Clicking the link sent me to this curiously-repeating URL:
`https://technet.microsoft.com/library/learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd568996(v=ws.10)?redirectedfrom=MSDN`

The other TechNet link on Line#53 seems to function just fine?
In case this happens to others, or in the event that this more than an intermittent issue, updating the link directly to the article on Microsoft Learn.
That page is archived/outdated, but the same could be said about this page, which doesn't change the fact that both are still pertinent and beneficial.

There are more recent readmes/references for specific Web Deployment Tool tasks, but I cannot seem to find anything like what we get from the `technet documentation` link. (when it works)
Maybe someone could confirm in case I just missed it; If/Where there is a newer version of this WebDeploy Tool/CLI reference which could be put here instead of updating the link for an outdated doc?

| File | Preview |
|:--|:--|
| 📄 _iis/publish/using-web-deploy/introduction-to-web-deploy.md_ | 🔗 [Preview: iis/publish/using-web-deploy/introduction-to-web-deploy](https://review.learn.microsoft.com/en-us/dotnet/iis/publish/using-web-deploy/introduction-to-web-deploy?branch=pr-en-us-964) |
