### PR TITLE
Revised the link to fix #526.

### DIFF
--- a/iis/develop/runtime-extensibility/develop-a-native-cc-module-for-iis.md
+++ b/iis/develop/runtime-extensibility/develop-a-native-cc-module-for-iis.md
@@ -156,6 +156,6 @@ The task is complete--we have finished configuring the new native module.
 
 ## Summary
 
-In this walkthrough, you learned how to develop and deploy a custom native module using the new native (C++) extensibility APIs. Please consult the [Native-Code Development Overview](../../web-developement-reference/native-code-development-overview/native-code-development-overview.md) to learn more about the native (C++) server APIs.
+In this walkthrough, you learned how to develop and deploy a custom native module using the new native (C++) extensibility APIs. Please consult the [Native-Code Development Overview](../../web-development-reference/native-code-development-overview/native-code-development-overview.md) to learn more about the native (C++) server APIs.
 
 To learn about extending IIS using managed code and the .NET framework, see [Developing an IIS module With .NET](developing-a-module-using-net.md). To learn more about managing IIS modules, see the [module overview white paper](../../get-started/introduction-to-iis/iis-modules-overview.md).

--- a/iis/develop/runtime-extensibility/develop-a-native-cc-module-for-iis.md
+++ b/iis/develop/runtime-extensibility/develop-a-native-cc-module-for-iis.md
@@ -156,6 +156,6 @@ The task is complete--we have finished configuring the new native module.
 
 ## Summary
 
-In this walkthrough, you learned how to develop and deploy a custom native module using the new native (C++) extensibility APIs. Please consult the [IIS 7.0 SDK documentation](../../get-started/whats-new-in-iis-10-version-1709/new-features-introduced-in-iis-10-1709.md) to learn more about the native (C++) server APIs.
+In this walkthrough, you learned how to develop and deploy a custom native module using the new native (C++) extensibility APIs. Please consult the [IIS 7.0 SDK documentation](../../web-developement-reference/native-code-development-overview/native-code-development-overview.md) to learn more about the native (C++) server APIs.
 
 To learn about extending IIS using managed code and the .NET framework, see [Developing an IIS module With .NET](developing-a-module-using-net.md). To learn more about managing IIS modules, see the [module overview white paper](../../get-started/introduction-to-iis/iis-modules-overview.md).

--- a/iis/develop/runtime-extensibility/develop-a-native-cc-module-for-iis.md
+++ b/iis/develop/runtime-extensibility/develop-a-native-cc-module-for-iis.md
@@ -156,6 +156,6 @@ The task is complete--we have finished configuring the new native module.
 
 ## Summary
 
-In this walkthrough, you learned how to develop and deploy a custom native module using the new native (C++) extensibility APIs. Please consult the [IIS 7.0 SDK documentation](../../web-developement-reference/native-code-development-overview/native-code-development-overview.md) to learn more about the native (C++) server APIs.
+In this walkthrough, you learned how to develop and deploy a custom native module using the new native (C++) extensibility APIs. Please consult the [Native-Code Development Overview](../../web-developement-reference/native-code-development-overview/native-code-development-overview.md) to learn more about the native (C++) server APIs.
 
 To learn about extending IIS using managed code and the .NET framework, see [Developing an IIS module With .NET](developing-a-module-using-net.md). To learn more about managing IIS modules, see the [module overview white paper](../../get-started/introduction-to-iis/iis-modules-overview.md).


### PR DESCRIPTION
The IIS 7 SDK Reference page doesn't seem to exist any more. Link to the native code development overview instead.