### PR TITLE
Update this page to remove deprecated references.

### DIFF
--- a/iis/extensions/introduction-to-iis-express/iis-express-overview.md
+++ b/iis/extensions/introduction-to-iis-express/iis-express-overview.md
@@ -20,20 +20,15 @@ IIS Express is a lightweight, self-contained version of IIS optimized for develo
 
 ## Installing IIS Express
 
-The most current version of the product is IIS 7.5 Express. Most of you will want to use IIS Express with a web authoring tool that provides an integrated experience.
+The most current version of the product is IIS 10.0 Express. Most of you will want to use IIS Express with a web authoring tool that provides an integrated experience.
 
-IIS Express is automatically included with [WebMatrix](https://www.microsoft.com/web/webmatrix "Microsoft WebMatrix"), a new and complete tool that greatly simplifies web development. Visual Studio 2010 SP1 allows IIS Express used as the web server instead of Cassini. You can also manually configure Visual Studio 2008.
+Visual Studio 2010 SP1 and later allow IIS Express used as the web server instead of Cassini. You can also manually configure IIS Express for other web authoring tools.
 
-Use one of the following links to install IIS 7.5 Express using Web Platform Installer. Either of them will allow you to use IIS Express with Visual Studio.
-
-- [Install Microsoft WebMatrix](https://www.microsoft.com/web/gallery/install.aspx?appid=WebMatrix "Install Microsoft WebMatrix"). This will install IIS 7.5 Express as well.
-- [Install IIS 7.5 Express only](https://www.microsoft.com/web/gallery/install.aspx?appid=IISExpress "Install IIS 7.5 Express"). After clicking the link, save the executable to your hard drive and run it. Doing so will install IIS Express using the [Web Platform Installer](../../install/web-platform-installer/using-the-microsoft-web-platform-installer.md "Web Platform Installer").
-
-You can also install the IIS 7.5 Express MSI directly from the [Microsoft Download Center](https://www.microsoft.com/downloads/en/details.aspx?FamilyID=abc59783-89de-4adc-b770-0a720bb21deb). If you choose this route, please make sure .NET 4.0 is installed on your machine, since that is a necessary prerequisite.
+You can install the IIS 10.0 Express MSI directly from the [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=48264). Please make sure .NET Framework 4.0 or above is installed on your machine, since that is a necessary prerequisite.
 
 ## IIS Express and IIS
 
-IIS Express is derived from IIS 7 and above and supports the core features of IIS; however, there are some key differences. An important difference is the way worker processes are managed. In IIS, the Windows Process Activation Service (WAS) silently activates and deactivates Web applications and the user has no direct control. In IIS Express, there is no WAS and the user has full control of application activation and deactivation. Sites can be launched using WebMatrix, Visual Studio 2010 SP1 or the command line; websites that are already running can be launched and terminated using the system tray application.
+IIS Express is derived from IIS 7 and above and supports the core features of IIS; however, there are some key differences. An important difference is the way worker processes are managed. In IIS, the Windows Process Activation Service (WAS) silently activates and deactivates Web applications and the user has no direct control. In IIS Express, there is no WAS and the user has full control of application activation and deactivation. Sites can be launched using Visual Studio or the command line; websites that are already running can be launched and terminated using the system tray application.
 
 Hostable Web Core (HWC) is an IIS API that can be used to write to independent Web servers that are not managed by WAS. IIS Express is designed as a wrapper over HWC.
 
@@ -41,8 +36,8 @@ The following chart outlines some of the major differences between IIS and IIS E
 
 | **Area** | **IIS** | **IIS Express** |
 | --- | --- | --- |
-| Shipping mechanism | Ships with the OS. | Ships out-of-band. It is automatically included with WebMatrix but can also be installed separately. |
-| Supported Windows editions | Limited number of Windows Vista and Windows 7 editions Most editions of Windows Server 2003, 2008 and 2008 R2 | All editions of Windows XP, Vista, Windows 7 All editions of Windows Server 2008 and 2008 R2 |
+| Shipping mechanism | Ships with the OS. | Ships out-of-band. It is automatically included with Visual Studio but can also be installed separately. |
+| Supported Windows editions | Limited number of Windows 10 and Windows 11 editions Most editions of Windows Server 2012, 2012 R2, 2016, 2019 and 2022 | All editions of Windows 10 and Windows 11 Most editions of Windows Server 2012, 2012 R2, 2016, 2019, and 2022 |
 | Supported .NET Framework versions | v2.0 SP1 and above | v2.0 SP1 and above (.NET 4.0 is required). |
 | Supported programming languages | Classic ASP, ASP.NET, and PHP | Classic ASP, ASP.NET, and PHP |
 | Process model | Windows Process Activation Service (WAS) automatically manages configured sites. | User launches and terminates sites. |
@@ -50,8 +45,8 @@ The following chart outlines some of the major differences between IIS and IIS E
 | Supported protocols | HTTP, FTP, WebDAV, HTTPS, and WCF (including over TCP, Named Pipes, and MSMQ) | HTTP, HTTPS, and WCF over HTTP |
 | Non-admin support | WAS must run with administrator user rights. | A standard user is allowed to complete most tasks. |
 | Multi-developer support | None | Yes. Configuration files, settings, and Web content are maintained on a per-user basis. |
-| Visual Studio support | Yes | VS 2010 SP1 Beta allows IIS Express to be used instead of Cassini. VS 2008 can also be manually configured to use IIS Express. |
+| Visual Studio support | Yes | VS 2010 SP1 and later allow IIS Express to be used instead of Cassini. |
 | Runtime extensions | See [https://www.iis.net/download/All](https://www.iis.net/downloads) for a complete list. | URL Rewrite and FastCGI. These extensions are built into IIS Express. |
-| Management tools | IIS Manager, appcmd.exe | Appcmd.exe. Common IIS Express management tasks are also built into WebMatrix and Visual Studio 2010 SP1 and later. |
+| Management tools | IIS Manager, appcmd.exe | Appcmd.exe. Common IIS Express management tasks are also built into Visual Studio 2010 SP1 and later. |
 | System tray support | None | Yes |
 | Includes built-in IIS modules for authentication, authorization, compression, etc. | Yes | Yes |


### PR DESCRIPTION
* The most recent release is now IIS 10 Express, not IIS 7.5 Express. As IIS 7.x reached end of life a long while ago, IIS 7.5 Express is likely to be deprecated as well.
* Visual Studio 2008, Web Platform Installer, and WebMatrix are end of life, so removed references about them.
* Removed deprecated Windows releases and added newer Windows releases.
* While VS 2010 and 2012 reached end of life, VS 2010 SP1 was the very first release to enable built-in IIS Express, so leave it in the article just for reference.