### PR TITLE
Use Windows L2 header

### DIFF
--- a/iis/docfx.json
+++ b/iis/docfx.json
@@ -40,6 +40,7 @@
     "globalMetadata": {
       "breadcrumb_path": "/iis/breadcrumb/toc.json",
       "extendBreadcrumb": "true",
+      "uhfHeaderId": "MSDocsHeader-Windows",
       "_navPath": "/foo",
       "_navRel": "/foo",
       "searchScope": [


### PR DESCRIPTION
This content is missing an L2 header, which is a required element. This PR adds uhfHeaderId to docfx file so that this content uses the Windows L2 header. If you feel that this content should use an L2 header other than Windows, please reply with a comment indicating which header it should use instead. Thank you! For more information see: https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main

@mcleblanc @Rick-Anderson Please review, thanks!