### PR TITLE
Fix breadcrumbs

### DIFF
--- a/iis/breadcrumb/toc.yml
+++ b/iis/breadcrumb/toc.yml
@@ -1,7 +1,3 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
-  items:
-  - name: IIS
-    tocHref: /iis/
-    topicHref: /iis
+- name: IIS
+  tocHref: /iis/
+  topicHref: /iis/index

--- a/iis/docfx.json
+++ b/iis/docfx.json
@@ -39,7 +39,6 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/iis/breadcrumb/toc.json",
-      "extendBreadcrumb": "true",
       "uhfHeaderId": "MSDocsHeader-Windows",
       "_navPath": "/foo",
       "_navRel": "/foo",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 