### PR TITLE
Remove incorrect count

### DIFF
--- a/iis/configuration/system.webServer/httpRedirect/index.md
+++ b/iis/configuration/system.webServer/httpRedirect/index.md
@@ -105,7 +105,7 @@ There is no user interface for adding wildcard HTTP redirects for IIS 7. For exa
 
    - Configure the redirection destination to be the exact destination as entered.
    - Configure the redirection destination to be limited to the destination URL's root folder, not subfolders.
-   - Configure the HTTP status code, which can be one of these three options:
+   - Configure the HTTP status code, which can be one of these options:
 
      - **301 Permanent**
      - **302 Found**


### PR DESCRIPTION
Instead of renaming to the correct number of codes ("four") I would suggest removing it entirely so this isn't missed when a new one comes along.