### PR TITLE
Fixed typo

### DIFF
--- a/iis/get-started/planning-your-iis-architecture/deep-dive-into-iis-configuration-with-iis-7-and-iis-8/samples/sample3.xml
+++ b/iis/get-started/planning-your-iis-architecture/deep-dive-into-iis-configuration-with-iis-7-and-iis-8/samples/sample3.xml
@@ -7,6 +7,6 @@
     <!-- "add" is the collection directive.                   -->
     <!-- "value" is a configuration property (XML attribute). -->
     <add value="Negotiate"/>
-    <add value=""NTLM/>
+    <add value="NTLM"/>
   </providers>
 </windowsAuthentication>


### PR DESCRIPTION
`"` was misplaced in the xml file.