### PR TITLE
Add a hint on restarting FTP service

### DIFF
--- a/iis/publish/using-the-ftp-service/configuring-ftp-firewall-settings-in-iis-7.md
+++ b/iis/publish/using-the-ftp-service/configuring-ftp-firewall-settings-in-iis-7.md
@@ -131,6 +131,7 @@ In this section, you configure the server-level port range for passive connectio
     - [929851 - The default dynamic port range for TCP/IP has changed in Windows Vista and in Windows Server 2008](https://support.microsoft.com/kb/929851/)
 
 4. This port range will need to be added to the allowed settings for your firewall server.
+5. After making the configuration changes, restart the Microsoft FTP Service. You can do this by going to Start > Run > services.msc and locating the FTP service.
 
 <a id="Step2"></a>
 

--- a/iis/publish/using-the-ftp-service/configuring-ftp-firewall-settings-in-iis-7.md
+++ b/iis/publish/using-the-ftp-service/configuring-ftp-firewall-settings-in-iis-7.md
@@ -131,7 +131,7 @@ In this section, you configure the server-level port range for passive connectio
     - [929851 - The default dynamic port range for TCP/IP has changed in Windows Vista and in Windows Server 2008](https://support.microsoft.com/kb/929851/)
 
 4. This port range will need to be added to the allowed settings for your firewall server.
-5. After making the configuration changes, restart the Microsoft FTP Service. You can do this by going to Start > Run > services.msc and locating the FTP service.
+5. After making the configuration changes, restart the Microsoft FTP Service via `Start` > `Run` > `services.msc` and locate the FTP service.
 
 <a id="Step2"></a>
 


### PR DESCRIPTION
Settings like passive port range require a service restart to take effect. Without such hints, users just don't know why their changes didn't work. There have been tons of previous threads on different online forums, so hope this change can avoid more in the future.