### PR TITLE
Fix IIS config sample by changing from HTML to XML

### DIFF
--- a/iis/get-started/planning-your-iis-architecture/deep-dive-into-iis-configuration-with-iis-7-and-iis-8.md
+++ b/iis/get-started/planning-your-iis-architecture/deep-dive-into-iis-configuration-with-iis-7-and-iis-8.md
@@ -211,7 +211,7 @@ This example shows how to unlock the section. Since it is locked at the applicat
 
 There are cases where it is useful to unlock sections for a specific path only and to keep them locked for all other paths. The following example builds atop the previous one, and shows how to unlock the section for two specific sites only; for all other sites it will remain locked.
 
-[!code-html[Main](deep-dive-into-iis-configuration-with-iis-7-and-iis-8/samples/sample8.html)]
+[!code-xml[Main](deep-dive-into-iis-configuration-with-iis-7-and-iis-8/samples/sample8.xml)]
 
 For each "exception" path that needs unlocking, there needs to be a different location tag.
 

--- a/iis/get-started/planning-your-iis-architecture/deep-dive-into-iis-configuration-with-iis-7-and-iis-8/samples/sample8.xml
+++ b/iis/get-started/planning-your-iis-architecture/deep-dive-into-iis-configuration-with-iis-7-and-iis-8/samples/sample8.xml
@@ -4,7 +4,7 @@
   </system.webServer>
 </location>
  
-<location path="TrustedSiteTwo" overrideMode="Allow"><span style="font-family:Calibri; font-size:11pt">				
+<location path="TrustedSiteTwo" overrideMode="Allow">
   <system.webServer>
     <modules/>
   </system.webServer>


### PR DESCRIPTION
I'm not sure how this `<span>` element got here, since obviously there are no span elements in the IIS config. I'm assuming it has something to do with the fact that these are old articles and they probably got converted into markdown after they were originally created. 