### PR TITLE
Update sample5.cmd to match test results

### DIFF
--- a/iis/manage/configuring-security/using-encryption-to-protect-passwords/samples/sample5.cmd
+++ b/iis/manage/configuring-security/using-encryption-to-protect-passwords/samples/sample5.cmd
@@ -1,13 +1,9 @@
-keyContainerName="NetFrameworkConfigurationKey" cspProviderName=""
-useMachineContainer="true" useOAEP="false" name="RsaProtectedConfigurationProvider"
-type="System.Configuration.RsaProtectedConfigurationProvider,System.Configuration,
+<configProtectedData defaultProvider="RsaProtectedConfigurationProvider">
+    <providers>
+        <add name="RsaProtectedConfigurationProvider" type="System.Configuration.RsaProtectedConfigurationProvider,System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" description="Uses RsaCryptoServiceProvider to encrypt and decrypt" keyContainerName="NetFrameworkConfigurationKey" cspProviderName="" useMachineContainer="true" useOAEP="false"/>
 
-Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-useMachineProtection="true" keyEntropy="" name="DataProtectionConfigurationProvider"
-type="System.Configuration.DpapiProtectedConfigurationProvider,System.Configuration,
-Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <add name="DataProtectionConfigurationProvider" type="System.Configuration.DpapiProtectedConfigurationProvider,System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" description="Uses CryptProtectData and CryptUnProtectData Windows APIs to encrypt and decrypt" useMachineProtection="true" keyEntropy=""/>
 
-cspProviderName="" useMachineContainer="true" useOAEP="false"
-name="Rsa_WAS"
-type="System.Configuration.RsaProtectedConfigurationProvider,System.Configuration,
-Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <add name="Rsa_WAS" type="System.Configuration.RsaProtectedConfigurationProvider,System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" description="RsaKeyForWAS" keyContainerName="iisWasKey" cspProviderName="" useMachineContainer="true" useOAEP="false" />
+    </providers>
+</configProtectedData>


### PR DESCRIPTION
https://learn.microsoft.com/iis/manage/configuring-security/using-encryption-to-protect-passwords

Based on the source code of `createProvider.exe` showed in this article, when its input is `iisWasKey RsaKeyForWAS Rsa_WAS`, it should add a provider in `machine.config` whose name is `Rsa_WAS`, with keyContainerName `iisWasKey` and description `RsaKeyForWAS`. However, the element in the old sample file didn't match.

Besides, the sample file should have showed enough context of all three provider items, so I chose to expand the contents to the entire `configProtectedData` tag. In this way, the `defaultProvider` attribute modified by `setProvider.exe` is also showed.

What this pull request doesn't include is the hint that how x86/x64 and .NET Framework 4.0+ scenarios should be handled, because the original article was only written with .NET Framework 2.0 and x86 in mind, but I assume the audience of this article is very small and should be capable enough.

@Rick-Anderson 