### PR TITLE
Added a note on HTTP status code 308

### DIFF
--- a/iis/extensions/url-rewrite-module/url-rewrite-module-configuration-reference.md
+++ b/iis/extensions/url-rewrite-module/url-rewrite-module-configuration-reference.md
@@ -207,6 +207,9 @@ A **Redirect** action has the following configuration options:
   - 303 – See other
   - 307 – Temporary
 
+  > [!NOTE]
+  > HTTP status code 308 (Permanent Redirect) is not supported by the URL Rewrite module.
+
 <a id="CustomResponse_action"></a>
 
 #### CustomResponse action


### PR DESCRIPTION
The background can be found in https://learn.microsoft.com/en-us/answers/questions/2243039/how-to-select-308-for-a-redirect-in-iis-10-url-rew

It seems that IIS 10 added HTTP status code 308 support in HTTP Redirect, in [IIS_Schema.xml](https://github.com/lextm/iis_schema/commit/2a639ef765f9ec6f40248762618ca8528c9d199b). However, URL Rewrite module wasn't updated accordingly.

This pull request adds a note in URL Rewrite documentation to point that out. Whether HTTP status code 308 should be supported by URL Rewrite module future releases is to be determined by the product owner.

@Rick-Anderson 