### PR TITLE
Fix typo in preloadEnabled attribute documentation

### DIFF
--- a/iis/configuration/system.applicationHost/sites/site/applicationDefaults.md
+++ b/iis/configuration/system.applicationHost/sites/site/applicationDefaults.md
@@ -2,7 +2,7 @@
 title: Application Defaults \<applicationDefaults>
 author: rick-anderson
 description: "Overview The &lt;applicationDefaults&gt; element of the &lt;site&gt; element specifies the default application settings for all applications in the parent si..."
-ms.date: 09/26/2016
+ms.date: 01/06/2026
 ms.assetid: 030aa9e7-7bd3-46bc-abb7-6c1cd066344a
 msc.legacyurl: /configreference/system.applicationhost/sites/site/applicationdefaults
 msc.type: config


### PR DESCRIPTION
This should be preloadEnabled, not preLoadEnabled according to the schema.  

<img width="610" height="375" alt="image" src="https://github.com/user-attachments/assets/27cdeb02-4b6a-4025-84ab-3b1b77addbeb" />
